### PR TITLE
Make handle-static-file work on clisp

### DIFF
--- a/misc.lisp
+++ b/misc.lisp
@@ -174,8 +174,6 @@ via the file's suffix."
             (content-length*) bytes-to-send)
       (let ((out (send-headers))
             (buf (make-array +buffer-length+ :element-type 'octet)))
-        #+:clisp
-        (setf (flexi-stream-element-type *hunchentoot-stream*) 'octet)
         (loop
            (when (zerop bytes-to-send)
              (return))


### PR DESCRIPTION
Remove a leftover read-time condition for clisp. The
_hunchentoot-stream_ isn't a flexi-stream anymore(?)

Backtrace produced when used in clisp: http://paste.lisp.org/+2PJ1
