### PR TITLE
Minor bug in WITH-LOG-STREAM

### DIFF
--- a/log.lisp
+++ b/log.lisp
@@ -62,5 +62,5 @@ facility."
                (stream
                 (let ((,stream-var ,destination))
                   (prog1 (progn ,@body)
-                    (finish-output *error-output*)))))))))))
+                    (finish-output ,destination)))))))))))
   


### PR DESCRIPTION
One instance of *ERROR-OUTPUT* was overlooked when the destination was being parameterized.
