### PR TITLE
Fix for handling of byte ranges

### DIFF
--- a/misc.lisp
+++ b/misc.lisp
@@ -132,9 +132,9 @@ had returned RESULT.  See the source code of REDIRECT for an example."
         ("^bytes=(\\d+)-(\\d*)$" (header-in* :range) :sharedp t)
       ;; body won't be executed if regular expression does not match
       (setf start (parse-integer start))
-      (if (> (length end) 0)
-          (setf end (parse-integer end))
-          (setf end (1- (file-length file))))
+      (setf end (if (> (length end) 0) 
+                    (parse-integer end) 
+                    (1- (file-length file))))
       (when (or (< start 0)
                 (>= end (file-length file)))
         (setf (return-code*) +http-requested-range-not-satisfiable+

--- a/test/script.lisp
+++ b/test/script.lisp
@@ -160,18 +160,18 @@ expecting certain responses."
       (http-request uploaded-file-url :range '(0 0))
       (http-assert 'status-code 206)
       (http-assert 'body 'equalp (subseq range-test-buffer 0 1))
-      (http-assert-header :content-range (format nil "bytes 0-0"))
+      (http-assert-header :content-range (format nil "bytes 0-0/~D" range-test-file-size))
 
       (say " End out of range")
       (http-request uploaded-file-url :range (list 0 range-test-file-size))
       (http-assert 'status-code 416)
-      (http-assert-header :content-range (format nil "bytes 0-~D/*" (1- range-test-file-size)))
+      (http-assert-header :content-range (format nil "bytes 0-~D/\\*" (1- range-test-file-size)))
 
       (say " Request whole file as partial")
       (http-request uploaded-file-url :range (list 0 (1- range-test-file-size)))
       (http-assert 'status-code 206)
       (http-assert 'body 'equalp range-test-buffer)
-      (http-assert-header :content-range (format nil "bytes 0-~D/*" (1- range-test-file-size)))
+      (http-assert-header :content-range (format nil "bytes 0-~D/~D" (1- range-test-file-size) range-test-file-size))
 
       (say " Request something in the middle")
       (let ((start-offset (/ range-test-file-size 4))
@@ -179,7 +179,7 @@ expecting certain responses."
         (http-request uploaded-file-url :range (list start-offset (1- length)))
         (http-assert 'status-code 206)
         (http-assert 'body 'equalp (subseq range-test-buffer start-offset length))
-        (http-assert-header :content-range (format nil "bytes ~D-~D" start-offset (1- length)))))
+        (http-assert-header :content-range (format nil "bytes ~D-~D/~D" start-offset (1- length) range-test-file-size))))
 
 
     (values)))


### PR DESCRIPTION
Range header: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
Content-Range header: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.16
