### PR TITLE
handle-static-file: with-open-file :if-file-does-not-exist option

### DIFF
--- a/misc.lisp
+++ b/misc.lisp
@@ -170,8 +170,7 @@ via the file's suffix."
     (handle-if-modified-since time)
     (with-open-file (file pathname
                           :direction :input
-                          :element-type 'octet
-                          :if-does-not-exist nil)
+                          :element-type 'octet)
       (setf bytes-to-send (maybe-handle-range-header file)
             (content-length*) bytes-to-send)
       (let ((out (send-headers))


### PR DESCRIPTION
unless I'm missing something the value of 'nil' for this option will bind stream var to nil if the file does not exists, but we already had handled that case (';; file does not exist') at the beginning of this function
