### PR TITLE
*upload-filename-generator*

### DIFF
--- a/doc/index.xml
+++ b/doc/index.xml
@@ -1751,12 +1751,12 @@
 
       <clix:special-variable name='*upload-filename-generator*'>
         <clix:description>
-         A filename designator for the uploaded file being written
-         to disk. It defaults to <code>NIL</code> in which case the internal
-         filename generator will be used. It also can be a <code>STRING</code> 
-         of the filename, a <code>PATHNAME</code>, or a <code>SYMBOL</code> 
-         which should be a function without arguments that returns the
-         filename <code>STRING</code>.
+         This is used to control how filename generation for the files being uploaded.
+         It defaults to <code>NIL</code> in which case the internal filename 
+         generator will be used. It can also be a <code>SYMBOL</code> (designating
+         a function) or a <code>Function</code>, in both cases the function should
+         have signature of (&key file-name field-name content-type), and should
+         return a filename to be used by the server to which uploaded content is written.
         </clix:description>
       </clix:special-variable>
 

--- a/request.lisp
+++ b/request.lisp
@@ -124,7 +124,7 @@ supposed to be of content type 'multipart/form-data'."
                              "BOUNDARY"
                              (rfc2388:header-parameters parsed-content-type-header)))
 		       (return-from parse-rfc2388-form-data))))
-    (loop for part in (rfc2388:parse-mime stream boundary :write-content-to-file (make-upload-filename))
+    (loop for part in (rfc2388:parse-mime stream boundary :write-content-to-file (make-upload-filename-generator))
           for headers = (rfc2388:mime-part-headers part)
           for content-disposition-header = (rfc2388:find-content-disposition-header headers)
           for name = (cdr (rfc2388:find-parameter

--- a/specials.lisp
+++ b/specials.lisp
@@ -254,11 +254,13 @@ the debugger).")
   "A list of temporary files created while a request was handled.")
 
 (defparameter *upload-filename-generator* nil
-  "A filename designator to be used by RFC2388 when uploaded file
-   is being written to disk. It defaults to NIL in which case the
-   internal generator is used. It also can be a STRING of the filename,
-   a PATHNAME, or a SYMBOL which should be a function that takes no
-   arguments and return the filename")
+  "This is used to control how filename generation for the files
+being uploaded. It defaults to NIL in which case the internal
+filename generator will be used. It can also be a SYMBOL (designating
+a function) or a Function, in both cases the function should have
+signature of (&key file-name field-name content-type), and should
+return a filename to be used by the server to which uploaded content
+is written.")
 
 (defconstant +latin-1+
   (make-external-format :latin1 :eol-style :lf)


### PR DESCRIPTION
This patch will allow the developer control over filename of the uploaded file before being written to disk.
