### PR TITLE
FIXED: Documentation/code discrepancy for acceptor-log-access

### DIFF
--- a/doc/index.xml
+++ b/doc/index.xml
@@ -758,13 +758,13 @@
       </clix:function>
 
       <clix:function name="acceptor-log-access" generic="true">
-        <clix:lambda-list>acceptor &amp;key return-code content content-length</clix:lambda-list>
+        <clix:lambda-list>acceptor &amp;key return-code</clix:lambda-list>
         <clix:description>
-          Function to call to log access to the acceptor.  The <clix:arg>return-code</clix:arg>,
-          <clix:arg>content</clix:arg> and <clix:arg>content-length</clix:arg> keyword arguments contain additional
+          Function to call to log access to the acceptor.  The
+          <clix:arg>return-code</clix:arg> keyword argument contains additional
           information about the request to log.  In addition, it can use the
-          standard request accessor functions that are available to handler
-          functions to find out more information about the request.
+          standard request and reply accessor functions that are available to
+          handler functions to find out more information about the request.
         </clix:description>
       </clix:function>
 


### PR DESCRIPTION
Found another small discrepancy between code and documentation regarding the list of arguments for acceptor-log-access. Here is the doc fix.
