### PR TITLE
FIXED: If an error is signaled during taskmaster thread creation, the taskmaster-request-count slot is not decremented

### DIFF
--- a/taskmaster.lisp
+++ b/taskmaster.lisp
@@ -367,6 +367,8 @@ is set up via PROCESS-REQUEST."
         (decrement-taskmaster-request-count taskmaster)))
     :name (format nil (taskmaster-worker-thread-name-format taskmaster) (client-as-string socket)))
    (error (cond)
+          ;; need to decrement the request count because we didn't reach the unwind-protect body.
+          (decrement-taskmaster-request-count taskmaster)
           ;; need to bind *ACCEPTOR* so that LOG-MESSAGE* can do its work.
           (let ((*acceptor* (taskmaster-acceptor taskmaster)))
             (log-message* *lisp-errors-log-level*


### PR DESCRIPTION
Mailing-list thread: https://mailman.common-lisp.net/pipermail/tbnl-devel/2012-August/003572.html

If an error is signaled during taskmaster thread creation (such as the
"getpeername": ENOTCONN error signaled during the generation of the thread
name), the body of the unwind-protect is never reached, and
taskmaster-request-count is never decremented. The counter eventually reaches
taskmaster-max-thread-count, preventing further requests to be processed by
hunchentoot.
