### PR TITLE
Fix taskmaster max accept count behavior

### DIFF
--- a/taskmaster.lisp
+++ b/taskmaster.lisp
@@ -87,21 +87,21 @@ This function is called by the acceptor's STOP method."))
     "Default method -- no limit on the number of connections."
     nil))
 
-(defgeneric taskmaster-request-count (taskmaster)
+(defgeneric taskmaster-thread-count (taskmaster)
   (:documentation
    "Returns the current number of taskmaster requests.")
   (:method ((taskmaster taskmaster))
     "Default method -- claim there is one connection thread."
     1))
 
-(defgeneric increment-taskmaster-request-count (taskmaster)
+(defgeneric increment-taskmaster-thread-count (taskmaster)
   (:documentation
    "Atomically increment the number of taskmaster requests.")
   (:method  ((taskmaster taskmaster))
     "Default method -- do nothing."
     nil))
 
-(defgeneric decrement-taskmaster-request-count (taskmaster)
+(defgeneric decrement-taskmaster-thread-count (taskmaster)
   (:documentation
    "Atomically decrement the number of taskmaster requests")
   (:method ((taskmaster taskmaster))
@@ -153,6 +153,18 @@ PROCESS-CONNECTION."))
     "The maximum number of request threads this taskmaster will simultaneously
      run before refusing or queueing new connections requests.  If the value
      is null, then there is no limit.")
+   (thread-count
+    :type integer
+    :initform 0
+    :accessor taskmaster-thread-count
+    :documentation
+    "The number of taskmaster processing threads currently running.")
+   (thread-count-lock
+    :initform (make-lock "taskmaster-thread-count")
+    :reader taskmaster-thread-count-lock
+    :documentation
+    "In the absence of 'atomic-incf', we need this to atomically
+     increment and decrement the request count.")
    (max-accept-count
     :type (or integer null)
     :initarg :max-accept-count
@@ -163,18 +175,19 @@ PROCESS-CONNECTION."))
      new connections.  If supplied, this must be greater than MAX-THREAD-COUNT.
      The number of queued requests is the difference between MAX-ACCEPT-COUNT
      and MAX-THREAD-COUNT.")
-   (request-count
+   (accept-count
     :type integer
     :initform 0
-    :accessor taskmaster-request-count
+    :accessor taskmaster-accept-count
     :documentation
-    "The number of taskmaster threads currently running.")
-   (request-count-lock
-    :initform (make-lock "taskmaster-request-count")
-    :reader taskmaster-request-count-lock
+    "The number of connection currently accepted by the taskmaster. These
+    connections are not ensured to be processed, thay may be waiting for an
+    empty processing slot or rejected because the load is too heavy.")
+   (accept-count-lock
+    :initform (make-lock "taskmaster-accept-count")
     :documentation
     "In the absence of 'atomic-incf', we need this to atomically
-     increment and decrement the request count.")
+     increment and decrement the accept count.")
    (wait-queue
     :initform (make-condition-variable)
     :reader taskmaster-wait-queue
@@ -206,6 +219,11 @@ MAX-ACCEPT-COUNT is supplied, it must be greater than MAX-THREAD-COUNT;
 in this case, requests are accepted up to MAX-ACCEPT-COUNT, and only
 then is HTTP 503 sent.
 
+It is important to note that MAX-ACCEPT-COUNT and the HTTP 503 behavior
+described above is racing with the acceptor listen backlog. If we are receiving
+requests faster than threads can be spawned and 503 sent, the requests will be
+silently rejected by the kernel.
+
 In a load-balanced environment with multiple Hunchentoot servers, it's
 reasonable to provide MAX-THREAD-COUNT but leave MAX-ACCEPT-COUNT null.
 This will immediately result in HTTP 503 when one server is out of
@@ -229,18 +247,29 @@ implementations."))
     (unless (> (taskmaster-max-accept-count taskmaster) (taskmaster-max-thread-count taskmaster))
       (parameter-error "MAX-ACCEPT-COUNT must be greater than MAX-THREAD-COUNT"))))
 
-(defmethod increment-taskmaster-request-count ((taskmaster one-thread-per-connection-taskmaster))
-  (when (taskmaster-max-thread-count taskmaster)
-    (with-lock-held ((taskmaster-request-count-lock taskmaster))
-      (incf (taskmaster-request-count taskmaster)))))
+(defmethod increment-taskmaster-accept-count ((taskmaster one-thread-per-connection-taskmaster))
+  (when (taskmaster-max-accept-count taskmaster)
+    (with-lock-held ((taskmaster-accept-count-lock taskmaster))
+      (incf (taskmaster-accept-count taskmaster)))))
 
-(defmethod decrement-taskmaster-request-count ((taskmaster one-thread-per-connection-taskmaster))
+(defmethod decrement-taskmaster-accept-count ((taskmaster one-thread-per-connection-taskmaster))
+  (when (taskmaster-max-accept-count taskmaster)
+    (with-lock-held ((taskmaster-accept-count-lock taskmaster))
+      (decf (taskmaster-accept-count taskmaster)))))
+
+(defmethod increment-taskmaster-thread-count ((taskmaster one-thread-per-connection-taskmaster))
+  (when (taskmaster-max-thread-count taskmaster)
+    (with-lock-held ((taskmaster-thread-count-lock taskmaster))
+      (incf (taskmaster-thread-count taskmaster)))))
+
+(defmethod decrement-taskmaster-thread-count ((taskmaster one-thread-per-connection-taskmaster))
   (when (taskmaster-max-thread-count taskmaster)
     (prog1
-        (with-lock-held ((taskmaster-request-count-lock taskmaster))
-          (decf (taskmaster-request-count taskmaster)))
+        (with-lock-held ((taskmaster-thread-count-lock taskmaster))
+          (decf (taskmaster-thread-count taskmaster))
+          (decrement-taskmaster-accept-count taskmaster))
       (when (and (taskmaster-max-accept-count taskmaster)
-                 (< (taskmaster-request-count taskmaster) (taskmaster-max-accept-count taskmaster)))
+                 (< (taskmaster-thread-count taskmaster) (taskmaster-max-accept-count taskmaster)))
         (note-free-connection taskmaster)))))
 
 (defmethod note-free-connection ((taskmaster one-thread-per-connection-taskmaster))
@@ -251,7 +280,7 @@ implementations."))
 (defmethod wait-for-free-connection ((taskmaster one-thread-per-connection-taskmaster))
   "Wait for a connection to be freed up"
   (with-lock-held ((taskmaster-wait-lock taskmaster))
-    (loop until (< (taskmaster-request-count taskmaster) (taskmaster-max-thread-count taskmaster))
+    (loop until (< (taskmaster-thread-count taskmaster) (taskmaster-max-thread-count taskmaster))
           do (condition-variable-wait (taskmaster-wait-queue taskmaster) (taskmaster-wait-lock taskmaster)))))
 
 (defmethod too-many-taskmaster-requests ((taskmaster one-thread-per-connection-taskmaster) socket)
@@ -286,6 +315,10 @@ implementations."))
 
 #-:lispworks
 (defmethod handle-incoming-connection ((taskmaster one-thread-per-connection-taskmaster) socket)
+  (create-request-handler-thread taskmaster socket))
+
+#-lispworks
+(defmethod handle-incoming-connection% ((taskmaster one-thread-per-connection-taskmaster) socket)
   ;; Here's the idea, with the stipulations given in ONE-THREAD-PER-CONNECTION-TASKMASTER
   ;;  - If MAX-THREAD-COUNT is null, just start a taskmaster
   ;;  - If the connection count will exceed MAX-ACCEPT-COUNT or if MAX-ACCEPT-COUNT
@@ -293,52 +326,58 @@ implementations."))
   ;;    return an HTTP 503 error to the client
   ;;  - Otherwise if we're between MAX-THREAD-COUNT and MAX-ACCEPT-COUNT,
   ;;    wait until the connection count drops, then handle the request
-  ;;  - Otherwise, increment REQUEST-COUNT and start a taskmaster
-  (cond ((null (taskmaster-max-thread-count taskmaster))
-         ;; No limit on number of requests, just start a taskmaster
-         (create-request-handler-thread taskmaster socket))
-        ((if (taskmaster-max-accept-count taskmaster)
-           (>= (taskmaster-request-count taskmaster) (taskmaster-max-accept-count taskmaster))
-           (>= (taskmaster-request-count taskmaster) (taskmaster-max-thread-count taskmaster)))
-         ;; Send HTTP 503 to indicate that we can't handle the request right now
-         (too-many-taskmaster-requests taskmaster socket)
-         (send-service-unavailable-reply taskmaster socket))
-        ((and (taskmaster-max-accept-count taskmaster)
-              (>= (taskmaster-request-count taskmaster) (taskmaster-max-thread-count taskmaster)))
-         ;; Wait for a request to finish, then carry on
-         (wait-for-free-connection taskmaster)
-         (increment-taskmaster-request-count taskmaster)
-         (create-request-handler-thread taskmaster socket))
-        (t
-         ;; We're within both limits, just start a taskmaster
-         (increment-taskmaster-request-count taskmaster)
-         (create-request-handler-thread taskmaster socket))))
+  ;;  - Otherwise, increment THREAD-COUNT and start a taskmaster
+  (increment-taskmaster-accept-count taskmaster)
+  (flet ((process-connection% (acceptor socket)
+           (increment-taskmaster-thread-count taskmaster)
+           (unwind-protect
+                (process-connection acceptor socket)
+             (decrement-taskmaster-thread-count taskmaster))))
+    (cond ((null (taskmaster-max-thread-count taskmaster))
+           ;; No limit on number of requests, just start a taskmaster
+           (process-connection (taskmaster-acceptor taskmaster) socket))
+          ((if (taskmaster-max-accept-count taskmaster)
+               (>= (taskmaster-accept-count taskmaster) (taskmaster-max-accept-count taskmaster))
+               (>= (taskmaster-thread-count taskmaster) (taskmaster-max-thread-count taskmaster)))
+           ;; Send HTTP 503 to indicate that we can't handle the request right now
+           (too-many-taskmaster-requests taskmaster socket)
+           (send-service-unavailable-reply taskmaster socket))
+          ((and (taskmaster-max-accept-count taskmaster)
+                (>= (taskmaster-thread-count taskmaster) (taskmaster-max-thread-count taskmaster)))
+           ;; Wait for a request to finish, then carry on
+           (wait-for-free-connection taskmaster)
+           (process-connection% (taskmaster-acceptor taskmaster) socket))
+          (t
+           ;; We're within both limits, just start a taskmaster
+           (process-connection% (taskmaster-acceptor taskmaster) socket)))))
 
 (defun send-service-unavailable-reply (taskmaster socket)
   "A helper function to send out a quick error reply, before any state
 is set up via PROCESS-REQUEST."
-  (let* ((acceptor (taskmaster-acceptor taskmaster))
-         (*acceptor* acceptor)
-         (*hunchentoot-stream*
-          (initialize-connection-stream acceptor (make-socket-stream socket acceptor)))
-         (*reply* (make-instance (acceptor-reply-class acceptor)))
-         (*request*
-          (multiple-value-bind (remote-addr remote-port)
-              (get-peer-address-and-port socket)
-            (make-instance (acceptor-request-class acceptor)
-              :acceptor acceptor
-              :remote-addr remote-addr
-              :remote-port remote-port
-              :headers-in nil
-              :content-stream nil
-              :method nil
-              :uri nil
-              :server-protocol nil))))
-    (with-character-stream-semantics
-      (send-response acceptor
-                     (flex:make-flexi-stream *hunchentoot-stream* :external-format :iso-8859-1)
-                     +http-service-unavailable+
-                     :content (acceptor-status-message acceptor +http-service-unavailable+)))))
+  (unwind-protect
+       (let* ((acceptor (taskmaster-acceptor taskmaster))
+              (*acceptor* acceptor)
+              (*hunchentoot-stream*
+               (initialize-connection-stream acceptor (make-socket-stream socket acceptor)))
+              (*reply* (make-instance (acceptor-reply-class acceptor)))
+              (*request*
+               (multiple-value-bind (remote-addr remote-port)
+                   (get-peer-address-and-port socket)
+                 (make-instance (acceptor-request-class acceptor)
+                                :acceptor acceptor
+                                :remote-addr remote-addr
+                                :remote-port remote-port
+                                :headers-in nil
+                                :content-stream nil
+                                :method nil
+                                :uri nil
+                                :server-protocol nil))))
+         (with-character-stream-semantics
+           (send-response acceptor
+                          (flex:make-flexi-stream *hunchentoot-stream* :external-format :iso-8859-1)
+                          +http-service-unavailable+
+                          :content (acceptor-status-message acceptor +http-service-unavailable+))))
+    (decrement-taskmaster-accept-count taskmaster)))
 
 #-:lispworks
 (defun client-as-string (socket)
@@ -362,19 +401,9 @@ is set up via PROCESS-REQUEST."
   (handler-case*
    (bt:make-thread
     (lambda ()
-      (unwind-protect
-           (process-connection (taskmaster-acceptor taskmaster) socket)
-        (decrement-taskmaster-request-count taskmaster)))
+      (handle-incoming-connection% taskmaster socket))
     :name (format nil (taskmaster-worker-thread-name-format taskmaster) (client-as-string socket)))
    (error (cond)
-          ;; The error occured during before the request handling
-          ;; thread was actually created - Most likely in the
-          ;; client-as-string function which potentially creates
-          ;; network errors because it tries to determine the address
-          ;; of the client.  Therefore, the unwind-protect in the
-          ;; handler thread above will never be executed and we need
-          ;; to do it here.
-          (decrement-taskmaster-request-count taskmaster)
           ;; need to bind *ACCEPTOR* so that LOG-MESSAGE* can do its work.
           (let ((*acceptor* (taskmaster-acceptor taskmaster)))
             (log-message* *lisp-errors-log-level*
@@ -402,24 +431,34 @@ is set up via PROCESS-REQUEST."
              (zerop (mod *worker-counter* *cleanup-interval*)))
     (when *cleanup-function*
       (funcall *cleanup-function*)))
-  (cond ((null (taskmaster-max-thread-count taskmaster))
-         ;; No limit on number of requests, just start a taskmaster
-         (create-request-handler-thread taskmaster socket))
-        ((if (taskmaster-max-accept-count taskmaster)
-           (>= (taskmaster-request-count taskmaster) (taskmaster-max-accept-count taskmaster))
-           (>= (taskmaster-request-count taskmaster) (taskmaster-max-thread-count taskmaster)))
-         ;; Send HTTP 503 to indicate that we can't handle the request right now
-         (too-many-taskmaster-requests taskmaster socket)
-         (send-service-unavailable-reply taskmaster socket))
-        ((and (taskmaster-max-accept-count taskmaster)
-              (>= (taskmaster-request-count taskmaster) (taskmaster-max-thread-count taskmaster)))
-         ;; Lispworks doesn't have condition variables, so punt
-         (too-many-taskmaster-requests taskmaster socket)
-         (send-service-unavailable-reply taskmaster socket))
-        (t
-         ;; We're within both limits, just start a taskmaster
-         (increment-taskmaster-request-count taskmaster)
-         (create-request-handler-thread taskmaster socket))))
+  (create-request-handler-thread taskmaster socket))
+
+#+:lispworks
+(defmethod handle-incoming-connection ((taskmaster one-thread-per-connection-taskmaster) socket)
+  (increment-taskmaster-accept-count taskmaster)
+  (flet ((process-connection% (acceptor socket)
+           (increment-taskmaster-thread-count taskmaster)
+           (unwind-protect
+                (process-connection acceptor socket)
+             (decrement-taskmaster-thread-count taskmaster))))
+    (cond ((null (taskmaster-max-thread-count taskmaster))
+           ;; No limit on number of requests, just start a taskmaster
+           (process-connection (taskmaster-acceptor taskmaster) socket))
+          ((if (taskmaster-max-accept-count taskmaster)
+               (>= (taskmaster-accept-count taskmaster) (taskmaster-max-accept-count taskmaster))
+               (>= (taskmaster-thread-count taskmaster) (taskmaster-max-thread-count taskmaster)))
+           ;; Send HTTP 503 to indicate that we can't handle the request right now
+           (too-many-taskmaster-requests taskmaster socket)
+           (send-service-unavailable-reply taskmaster socket))
+          ((and (taskmaster-max-accept-count taskmaster)
+                (>= (taskmaster-thread-count taskmaster) (taskmaster-max-thread-count taskmaster)))
+           ;; Lispworks doesn't have condition variables, so punt
+           (too-many-taskmaster-requests taskmaster socket)
+           (send-service-unavailable-reply taskmaster socket))
+          (t
+           ;; We're within both limits, just start a taskmaster
+           (increment-taskmaster-thread-count taskmaster)
+           (process-connection% (taskmaster-acceptor taskmaster) socket)))))
 
 #+:lispworks
 (defmethod create-request-handler-thread ((taskmaster one-thread-per-connection-taskmaster) socket)
@@ -427,6 +466,4 @@ is set up via PROCESS-REQUEST."
                                    (multiple-value-list (get-peer-address-and-port socket)))
                            nil
                            (lambda ()
-                             (unwind-protect
-                                 (process-connection (taskmaster-acceptor taskmaster) socket)
-                               (decrement-taskmaster-request-count taskmaster)))))
+                             (handle-incoming-connection% taskmaster socket))))


### PR DESCRIPTION
# Notes:
1. I have another pull request regarding fd exhaustion when the connection is prematurely closed (on either side), however, it is not merge-compatible with this one, so I prefer to wait considering this one first. I found the current issue while looking for the source of fd exhaustion.
2. If you think it is useful, I may also prepare a patch to fix the apparent discrepancies between the LW implementation and the generic one (regarding create-request-handler-thread, which does not seem to be impervious to fix/error-while-creating-thread-does-not-decrement-request-counter, nor to Jul 06, 2009 (Handle conditions signaled during worker process creation) fix.
# Notes on the Pull request itself:
1. This fix includes two modifications, merged together in the first commit. If you prefer to have one commit for each modification, simply say so and I will split the commit in two.
2. I also tried to port my fix to the LW implementation, however, since both implementations are not following the exact same execution path, I may have made an error or overlook something that would be LW specific. The LW backport is therefore in a separated commit.

Here is a copy of the first commit message (plus formatting and an additional proof-reading pass), explaining in details the issues and the fixes I applied (or considered).

Several issues had to be considered to end up with the correct behavior:
## Threading behavior:

`taskmaster-max-accept-count` was not respected because `handle-incoming-connection`
was executed in the main acceptor thread. As soon as `taskmaster-request-count`
reached `taskmaster-max-thread-count`, the thread was put to sleep. The new
connections were therefore not accepted, eventually reaching the acceptor listen
backlog limit and being silently dropped by the kernel (instead of returning an
HTTP 503 answer).
### FIX: _The handler thread is now spawned earlier_

That way the main acceptor thread is not blocked.
## Counter behavior:

Moreover, even with the thread spawned earlier, the behavior was not valid: in
`handle-incoming-connection`, when `taskmaster-request-count` reached
`taskmaster-max-thread-count`, the current handling thread was put to sleep,
without incrementing `taskmaster-request-count` first. Thus
`taskmaster-request-count` would never reach `taskmaster-max-accept-count` and never
trigger the `too-many-taskmaster-requests behavior` (and sending an HTTP 503
answer).

The acceptor would therefore keep accepting new connections until eventually
exhausting the available amount of file descriptors (fds) allowed for each
process (given an heavy enough load).
### SUGGESTED FIX: _incrementing `taskmaster-request-count` earlier_

This solution is not acceptable. Although it would actually fix the fd
exhaustion and adequately trigger the `too-many-taskmaster-requests` behavior, we
would expose ourselves to the following scenario:

Let's take `taskmaster-max-thread-count` = 100 and `taskmaster-max-accept-count` =
120 (which are the default values). Let's assume 140 requests are received by
the server quickly enough for the last request to be accepted before the first
processing is complete, but not quickly enough for the number of
not-yet-accepted connections to reach the acceptor listen backlog (iow, all
requests are given to `handle-incoming-connection` more or less
simultaneously):

The first 100 requests will start being processed right away
(`taskmaster-request-count` < `taskmaster-max-thread-count`), the next 20 requests
will be put into a waiting state (`taskmaster-max-thread-count` <=
`taskmaster-request-count` < `taskmaster-max-accept-count`) and the last 20 requests
will be rejected with an HTTP 503 answer (`taskmaster-request-count` >=
`taskmaster-max-accept-count`).

`taskmaster-request-count` will now have the value 120. Once the first 10 requests
processing are completed, it will be decreased to 110 (with 20 threads still in
waiting state and 90 requests being processed). Although `note-free-connection`
will have been called (10 times), the condition in `wait-for-free-connection`
(`taskmaster-request-count` < `taskmaster-max-thread-count`) will never be satisfied
and no thread will be woken up. Until 11 more requests processing are completed
and `taskmaster-request-count` finaly reaches 99, at which point, one thread will
be woken up. For a grand total of 80 requests being processed while 20 others
are still sleeping (!). The requests will therefore be put to sleep much longer
than they would need.

Even worse, if `taskmaster-max-accept-count` > 2*`taskmaster-max-thread-count`,
there will always be too many sleeping threads for `taskmaster-request-count` to
ever reach `taskmaster-max-thread-count` and hunchentoot will eventually reject
any new request without processing any old request currently waiting.
### FIX: _using 2 separated counters, one for accepted connections, one for processed connections_

We now use two different counters. While `taskmaster-request-count` still count
the number of requests being processed (and we didn't change its
increment/decrement strategy, we created another counter,
`taskmaster-accept-count`, which is counting the number of requests that have been
currently accepted (iow, the REAL number of thread currently spawned, either
being processed or in a waiting state). This counter is incremented by
`handle-incoming-connection%` as soon as we fork from the acceptor thread and is
decremented before the end of thread, either in `send-service-unavailable-reply`
or when the number `taskmaster-request-count` is decremented.
## Acceptor listen backlog race condition

Of course, if the load is so heavy that hunchentoot receives requests faster
than it can send HTTP 503 answers, the acceptor listen backlog will eventually
be reached and connections will be silently closed.

To fix this issue would mean to set an extremely high listen backlog (or disable
it altogether). However, that would delay the moment by which hunchentoot fall
back to a stable state after the heavy load spike because it would have to send
an HTTP 503 answer for each and every connection waiting to be accepted. This
solution is therefore perceived as increasing the probability of hunchentoot
failing to process queries in case of consecutives spikes and slowing down the
recovery process.

This behavior is thus deemed as acceptable, if not wanted, in order to guarantee
a better reliability under consecutive spike/heavy load.
