### PR TITLE
send-service-unavailable-reply fails to protect the software from random conditions.

### DIFF
--- a/acceptor.lisp
+++ b/acceptor.lisp
@@ -316,17 +316,7 @@ they're using secure connections - see the SSL-ACCEPTOR class."))
 (defmethod process-connection :around ((*acceptor* acceptor) (socket t))
   ;; this around method is used for error handling
   ;; note that this method also binds *ACCEPTOR*
-  (handler-bind ((error
-                  ;; abort if there's an error which isn't caught inside
-                  (lambda (cond)
-                    (log-message* *lisp-errors-log-level*
-                                  "Error while processing connection: ~A" cond)
-                    (return-from process-connection)))
-                 (warning
-                  ;; log all warnings which aren't caught inside
-                  (lambda (cond)
-                    (log-message* *lisp-warnings-log-level*
-                                  "Warning while processing connection: ~A" cond))))
+  (with-conditions-caught-and-logged ()
     (with-mapped-conditions ()
       (call-next-method))))
 

--- a/util.lisp
+++ b/util.lisp
@@ -337,3 +337,21 @@ not a chunked stream."
   #-:lispworks
   `(usocket:with-mapped-conditions ()
     ,@body))
+
+(defmacro with-conditions-caught-and-logged (() &body body)
+  "Run BODY with conditions caught and logged by the *ACCEPTOR*. Errors are
+stopped right away so no other part of the software is impacted by them."
+  `(block nil
+     (handler-bind
+         ((error
+           ;; abort if there's an error which isn't caught inside
+           (lambda (cond)
+             (log-message* *lisp-errors-log-level*
+                           "Error while processing connection: ~A" cond)
+             (return)))
+          (warning
+           ;; log all warnings which aren't caught inside
+           (lambda (cond)
+             (log-message* *lisp-warnings-log-level*
+                           "Warning while processing connection: ~A" cond))))
+       ,@body)))


### PR DESCRIPTION
Hi Hans,

Here is another fix, even more critical than the previous one (fd exhaustion) because a single well-timed (and no so much harder to generate) connection could crash completely hunchentoot.

If a client closes prematurely a request that was supposed to be handled as a
503. The condtion is going to bubble up and end up unhandled, crashing the whole
process. The protection mecanism implementated in `process-connection :around`
is now re-implemented here.

This _may_ be related to the issue discussed in PR 39.
