### PR TITLE
Update *hunchentoot-version*

### DIFF
--- a/hunchentoot.asd
+++ b/hunchentoot.asd
@@ -33,7 +33,7 @@
 
 (in-package :hunchentoot-asd)
 
-(defvar *hunchentoot-version* "1.2.5"
+(defvar *hunchentoot-version* "1.2.7"
   "A string denoting the current version of Hunchentoot.  Used
 for diagnostic output.")
 


### PR DESCRIPTION
hunchentoot-1.2.6 shipped with this set wrong as well.  Figuring out a good strategy for setting versions inside source files especially in the presence of DVCS always seems problematic.
