### PR TITLE
Fix cause of unnecessary warnings

### DIFF
--- a/request.lisp
+++ b/request.lisp
@@ -305,7 +305,9 @@ no Content-Length header and input chunking is off.")
           (let ((external-format (or external-format
                                      (when charset
                                        (handler-case
-                                           (make-external-format charset :eol-style :lf)
+                                           (make-external-format
+                                            (intern (string-upcase charset) :keyword)
+                                            :eol-style :lf)
                                          (error ()
                                            (hunchentoot-warn "Ignoring ~
 unknown character set ~A in request content type."
@@ -339,7 +341,7 @@ during the request."
   (setf (slot-value request 'get-parameters)
         (form-url-encoded-list-to-alist (split "&" (query-string request)) external-format))
   (values))
-                                                
+
 (defun script-name* (&optional (request *request*))
   "Returns the file name of the REQUEST object REQUEST. That's the
 requested URI without the query string \(i.e the GET parameters)."


### PR DESCRIPTION
I'm getting warnings of the form:

 "Warning while processing connection: Ignoring unknown character set UTF-8 in request content type."

because FLEX:MAKE-EXTERNAL-FORMAT is being passed a string when it should be passed a keyword.

This commit fixes that.

P.S. Sorry about the two master branch merges - I don't fully understand how they became part of this pull request.