### PR TITLE
m4v mime type

### DIFF
--- a/mime-types.lisp
+++ b/mime-types.lisp
@@ -334,6 +334,7 @@
                                  ("video/quicktime" "qt" "mov")
                                  ("video/vnd.mpegurl" "mxu")
                                  ("video/x-la-asf" "lsf" "lsx")
+                                 ("video/x-m4v" "m4v")
                                  ("video/x-mng" "mng")
                                  ("video/x-ms-asf" "asf" "asx")
                                  ("video/x-ms-wm" "wm")


### PR DESCRIPTION
Hi Hans,

This adds a mime type for the m4v file format (http://en.wikipedia.org/wiki/M4V). Looks like it is not an official standard, but seeing as both Apache and nginx currently recognize m4v as video/x-m4v, it seems safe to do the same.

For what it's worth, it is working for some mocl videos e.g. https://wukix.com/dist/contacts_scrolling.m4v
