### PR TITLE
file upload file name encoding error fixed

### DIFF
--- a/request.lisp
+++ b/request.lisp
@@ -143,10 +143,7 @@ supposed to be of content type 'multipart/form-data'."
                         (let ((contents (rfc2388:mime-part-contents part)))
                           (if (pathnamep contents)
                             (list contents
-                                  ; Edit by muyinliu 20140303
-                                  ;(rfc2388:get-file-name headers) 
                                   (convert-hack (rfc2388:get-file-name headers) external-format)
-
                                   (rfc2388:content-type part :as-string t))
                             (convert-hack contents external-format)))))))
 


### PR DESCRIPTION
While uploading a file with name using non-ASCII character, hunchentoot lead to charset encoding error.  This fix shows a solution.
