### PR TITLE
Fix request parameter handler of type boolean

### DIFF
--- a/easy-handlers.lisp
+++ b/easy-handlers.lisp
@@ -58,7 +58,11 @@ NIL unconditionally."
                     (char argument 0)))
     (integer (ignore-errors* (parse-integer argument :junk-allowed t)))
     (keyword (as-keyword argument :destructivep nil))
-    (boolean t)
+    (boolean (if (or (equal argument "1")
+                     (string-equal argument "true")
+                     (string-equal argument "t"))
+                  t
+                  nil))
     (otherwise (funcall type argument))))
 
 (defun compute-simple-parameter (parameter-name type parameter-reader)


### PR DESCRIPTION
Old code will lead to an ERROR: if define a parameter's type to 'boolean, whatever the value passed(even empty string), the value of the parameter is T.

The fix will make this come true: if define a parameter's type to 'boolean, if passing "1", "true" or "t", the value of the parameter is T, otherwise the value of the parameter is NIL.
