### PR TITLE
fix warning about missing NAME keyword arg at start-thread

### DIFF
--- a/taskmaster.lisp
+++ b/taskmaster.lisp
@@ -108,7 +108,7 @@ This function is called by the acceptor's STOP method."))
     "Default method -- do nothing."
     nil))
 
-(defgeneric start-thread (taskmaster thunk &key)
+(defgeneric start-thread (taskmaster thunk &key name)
   (:documentation
    "Start a name thread in which to call the THUNK, in the context of the given TASKMASTER.
 Keyword arguments provide TASKMASTER-dependent options.


### PR DESCRIPTION
This gets rid of a warning like

```
;Compiler warnings for "home:hunchentoot-patch;hunchentoot;taskmaster.lisp.newest" :
;   In (HUNCHENTOOT:CREATE-REQUEST-HANDLER-THREAD (HUNCHENTOOT:ONE-THREAD-PER-CONNECTION-TASKMASTER T)) inside an anonymous lambda form: In the call to HUNCHENTOOT:START-THREAD with arguments (HUNCHENTOOT:TASKMASTER #'(LAMBDA NIL (HUNCHENTOOT::HANDLE-INCOMING-CONNECTION% HUNCHENTOOT:TASKMASTER HUNCHENTOOT::SOCKET)) :NAME (FORMAT NIL (HUNCHENTOOT::TASKMASTER-WORKER-THREAD-NAME-FORMAT HUNCHENTOOT:TASKMASTER) (HUNCHENTOOT:CLIENT-AS-STRING HUNCHENTOOT::SOCKET))),
;     the keyword argument :NAME is not recognized by the definition of HUNCHENTOOT:START-THREAD visible in the current compilation unit.
;   In (HUNCHENTOOT:EXECUTE-ACCEPTOR (HUNCHENTOOT:MULTI-THREADED-TASKMASTER)) inside an anonymous lambda form: In the call to HUNCHENTOOT:START-THREAD with arguments (HUNCHENTOOT:TASKMASTER #'(LAMBDA NIL (HUNCHENTOOT:ACCEPT-CONNECTIONS (HUNCHENTOOT:TASKMASTER-ACCEPTOR HUNCHENTOOT:TASKMASTER))) :NAME (FORMAT NIL "hunchentoot-listener-~A:~A" (OR (HUNCHENTOOT:ACCEPTOR-ADDRESS (HUNCHENTOOT:TASKMASTER-ACCEPTOR HUNCHENTOOT:TASKMASTER)) "*") (HUNCHENTOOT:ACCEPTOR-PORT (HUNCHENTOOT:TASKMASTER-ACCEPTOR HUNCHENTOOT:TASKMASTER)))),
;     the keyword argument :NAME is not recognized by the definition of HUNCHENTOOT:START-THREAD visible in the current compilation unit.
```
