### PR TITLE
Make check for stream timeouts more robust

### DIFF
--- a/lispworks.lisp
+++ b/lispworks.lisp
@@ -94,17 +94,22 @@ notation."
       (comm:get-socket-address socket)
     (values (ignore-errors (comm:ip-address-string local-addr)) local-port)))
 
+(eval-when (:compile-toplevel :load-toplevel)
+  (when (let ((sym (find-symbol "STREAM-READ-TIMEOUT" :stream)))
+          (and sym (fboundp sym)))
+    (pushnew :stream-has-timeouts *features*)))
+
 (defun make-socket-stream (socket acceptor)
   "Returns a stream for the socket SOCKET.  The ACCEPTOR argument is
 used to set the timeouts."
-  #-(or :lispworks5 :lispworks6)
+  #-stream-has-timeouts
   (when (acceptor-write-timeout acceptor)
     (parameter-error "You need LispWorks 5 or higher for write timeouts."))
   (make-instance 'comm:socket-stream
                  :socket socket
                  :direction :io
                  :read-timeout (acceptor-read-timeout acceptor)
-                 #+(or :lispworks5 :lispworks6) #+(or :lispworks5 :lispworks6)
+                 #+stream-has-timeouts #+stream-has-timeouts
                  :write-timeout (acceptor-write-timeout acceptor)
                  :element-type 'octet))
 


### PR DESCRIPTION
Use explicit feature check for stream-{read,write}-timeout, instead of
checking for specific Lispworks versions (which will have to be extended
for each new major release).
