### PR TITLE
Adds the session-regenerate-cookie-value function

### DIFF
--- a/doc/index.xml
+++ b/doc/index.xml
@@ -2579,7 +2579,16 @@
         <clix:returns>cookie
         </clix:returns>
         <clix:description>
-          Regenerates the session cookie value.
+          Regenerates the session cookie value. This should be used
+          when a user logs in according to the application to prevent
+          against session fixation attacks. The cookie value being
+          dependent on ID, USER-AGENT, REMOTE-ADDR, START, and
+          *SESSION-SECRET*, the only value we can change is START to
+          regenerate a new value. Since we're generating a new cookie,
+          it makes sense to have the session being restarted, in
+          time. That said, because of this fact, calling this function
+          twice in the same second will regenerate twice the same
+          value.
         </clix:description>
       </clix:function>
 

--- a/doc/index.xml
+++ b/doc/index.xml
@@ -2468,8 +2468,8 @@
       </p>
       <p>
         Hunchentoot also provides a <clix:ref>SESSION-REGENERATE-COOKIE-VALUE</clix:ref>
-        generic function that creates a new cookie value. This helps to prevent
-        against <a href="https://www.owasp.org/index.php/Session_fixation">session fixation
+        function that creates a new cookie value. This helps to prevent against
+        <a href="https://www.owasp.org/index.php/Session_fixation">session fixation
         attacks</a>, and should be used when a user logs in according to the application.
       </p>
 

--- a/doc/index.xml
+++ b/doc/index.xml
@@ -2573,6 +2573,16 @@
         </clix:description>
       </clix:function>
 
+      <clix:function name='regenerate-session-cookie-value'>
+        <clix:lambda-list>session
+        </clix:lambda-list>
+        <clix:returns>cookie
+        </clix:returns>
+        <clix:description>
+          Regenerates the session cookie value.
+        </clix:description>
+      </clix:function>
+
       <clix:special-variable name='*rewrite-for-session-urls*'>
         <clix:description>
           Whether HTML pages should possibly be rewritten for cookie-less
@@ -2695,17 +2705,6 @@
         </clix:returns>
         <clix:description>
           The time this session was started.
-        </clix:description>
-      </clix:function>
-
-      <clix:function generic='true' name='session-regenerate-cookie-value'>
-        <clix:lambda-list>session
-        </clix:lambda-list>
-        <clix:returns>cookie
-        </clix:returns>
-        <clix:description>
-          Regenerates the session cookie value. Because of technical limitations,
-          this function should not be called twice in the same second.
         </clix:description>
       </clix:function>
 

--- a/doc/index.xml
+++ b/doc/index.xml
@@ -2466,6 +2466,12 @@
         not <a href="#session-too-old-p">too old</a>.  Old sessions
         are <a href="#session-gc">automatically removed</a>.
       </p>
+      <p>
+        Hunchentoot also provides a <clix:ref>SESSION-REGENERATE-COOKIE-VALUE</clix:ref>
+        generic function that creates a new cookie value. This helps to prevent
+        against <a href="https://www.owasp.org/index.php/Session_fixation">session fixation
+        attacks</a>, and should be used when a user logs in according to the application.
+      </p>
 
       <clix:class name='session'>
         <clix:description>
@@ -2692,6 +2698,16 @@
         </clix:description>
       </clix:function>
 
+      <clix:function generic='true' name='session-regenerate-cookie-value'>
+        <clix:lambda-list>session
+        </clix:lambda-list>
+        <clix:returns>cookie
+        </clix:returns>
+        <clix:description>
+          Regenerates the session cookie value. Because of technical limitations,
+          this function should not be called twice in the same second.
+        </clix:description>
+      </clix:function>
 
     </clix:subchapter>
 

--- a/packages.lisp
+++ b/packages.lisp
@@ -268,6 +268,7 @@
            #:session-user-agent
            #:session-value
            #:session-verify
+           #:session-regenerate-cookie-value
            #:set-cookie
            #:set-cookie*
            #:shutdown

--- a/packages.lisp
+++ b/packages.lisp
@@ -222,6 +222,7 @@
            #:recompute-request-parameters
            #:redirect
            #:referer
+           #:regenerate-session-cookie-value
            #:remote-addr
            #:remote-addr*
            #:remote-port
@@ -268,7 +269,6 @@
            #:session-user-agent
            #:session-value
            #:session-verify
-           #:session-regenerate-cookie-value
            #:set-cookie
            #:set-cookie*
            #:shutdown

--- a/session.lisp
+++ b/session.lisp
@@ -297,20 +297,17 @@ will not create a new one."
       (setq session nil))
     session))
 
-(defgeneric session-regenerate-cookie-value (session)
-  (:documentation "Regenerates the cookie value. This should be used
+(defun regenerate-session-cookie-value (session)
+  "Regenerates the cookie value. This should be used
 when a user logs in according to the application to prevent against
-session fixation attacks."))
-
-(defmethod session-regenerate-cookie-value ((session session))
-  "The cookie value being dependent on ID, USER-AGENT, REMOTE-ADDR,
-START, and *SESSION-SECRET*, the only value we can change is START
-to regenerate a new value. Since we're generating a new cookie, it
-makes sense to have the session being restarted, in time. That said,
-because of this fact, calling this function twice in the same second
-will regenerate twice the same value."
-  (setf (slot-value session 'session-start) (get-universal-time))
-  (setf (slot-value session 'session-string) (stringify-session session))
+session fixation attacks. The cookie value being dependent on ID,
+USER-AGENT, REMOTE-ADDR, START, and *SESSION-SECRET*, the only value
+we can change is START to regenerate a new value. Since we're
+generating a new cookie, it makes sense to have the session being
+restarted, in time. That said, because of this fact, calling this
+function twice in the same second will regenerate twice the same value."
+  (setf (slot-value session 'session-start) (get-universal-time)
+        (slot-value session 'session-string) (stringify-session session))
   (set-cookie (session-cookie-name *acceptor*)
               :value (session-cookie-value session)
               :path "/"

--- a/www/hunchentoot-doc.html
+++ b/www/hunchentoot-doc.html
@@ -2467,6 +2467,16 @@
           <code><a href="#*acceptor*">*ACCEPTOR*</a></code>.
         </clix:description></blockquote></p>
 
+      <p xmlns=""><a class="none" name="regenerate-session-cookie-value"></a>
+          [Function]
+          <br><b>regenerate-session-cookie-value</b> <i><clix:lambda-list xmlns:clix="http://bknr.net/clixdoc">session
+        </clix:lambda-list></i>
+            =&gt;
+            <i><clix:returns xmlns:clix="http://bknr.net/clixdoc">cookie
+        </clix:returns></i><blockquote><clix:description xmlns:clix="http://bknr.net/clixdoc">
+          Regenerates the session cookie value.
+        </clix:description></blockquote></p>
+
       <p xmlns=""><a class="none" name="*rewrite-for-session-urls*"></a>
       [Special variable]
       <br><b>*rewrite-for-session-urls*</b><blockquote><clix:description xmlns:clix="http://bknr.net/clixdoc">
@@ -2591,17 +2601,6 @@
             <i><clix:returns xmlns:clix="http://bknr.net/clixdoc">universal-time
         </clix:returns></i><blockquote><clix:description xmlns:clix="http://bknr.net/clixdoc">
           The time this session was started.
-        </clix:description></blockquote></p>
-
-      <p xmlns=""><a class="none" name="session-regenerate-cookie-value"></a>
-          [Generic function]
-          <br><b>session-regenerate-cookie-value</b> <i><clix:lambda-list xmlns:clix="http://bknr.net/clixdoc">session
-        </clix:lambda-list></i>
-            =&gt;
-            <i><clix:returns xmlns:clix="http://bknr.net/clixdoc">cookie
-        </clix:returns></i><blockquote><clix:description xmlns:clix="http://bknr.net/clixdoc">
-          Regenerates the session cookie value. Because of technical limitations,
-          this function should not be called twice in the same second.
         </clix:description></blockquote></p>
 
     
@@ -3990,6 +3989,9 @@ start and test an https server instead.)
 <code><a href="#referer">referer</a></code><span class="entry-type">Function</span>
 </li>
 <li>
+<code><a href="#regenerate-session-cookie-value">regenerate-session-cookie-value</a></code><span class="entry-type">Function</span>
+</li>
+<li>
 <code><a href="#remote-addr">remote-addr</a></code><span class="entry-type">Generic reader</span>
 </li>
 <li>
@@ -4093,9 +4095,6 @@ start and test an https server instead.)
 </li>
 <li>
 <code><a href="#session-max-time">session-max-time</a></code><span class="entry-type">Generic accessor</span>
-</li>
-<li>
-<code><a href="#session-regenerate-cookie-value">session-regenerate-cookie-value</a></code><span class="entry-type">Generic function</span>
 </li>
 <li>
 <code><a href="#session-remote-addr">session-remote-addr</a></code><span class="entry-type">Generic function</span>

--- a/www/hunchentoot-doc.html
+++ b/www/hunchentoot-doc.html
@@ -2474,7 +2474,16 @@
             =&gt;
             <i><clix:returns xmlns:clix="http://bknr.net/clixdoc">cookie
         </clix:returns></i><blockquote><clix:description xmlns:clix="http://bknr.net/clixdoc">
-          Regenerates the session cookie value.
+          Regenerates the session cookie value. This should be used
+          when a user logs in according to the application to prevent
+          against session fixation attacks. The cookie value being
+          dependent on ID, USER-AGENT, REMOTE-ADDR, START, and
+          *SESSION-SECRET*, the only value we can change is START to
+          regenerate a new value. Since we're generating a new cookie,
+          it makes sense to have the session being restarted, in
+          time. That said, because of this fact, calling this function
+          twice in the same second will regenerate twice the same
+          value.
         </clix:description></blockquote></p>
 
       <p xmlns=""><a class="none" name="*rewrite-for-session-urls*"></a>

--- a/www/hunchentoot-doc.html
+++ b/www/hunchentoot-doc.html
@@ -2359,8 +2359,8 @@
       </p>
       <p>
         Hunchentoot also provides a <code xmlns=""><a href="#session-regenerate-cookie-value">SESSION-REGENERATE-COOKIE-VALUE</a></code>
-        generic function that creates a new cookie value. This helps to prevent
-        against <a href="https://www.owasp.org/index.php/Session_fixation">session fixation
+        function that creates a new cookie value. This helps to prevent against
+        <a href="https://www.owasp.org/index.php/Session_fixation">session fixation
         attacks</a>, and should be used when a user logs in according to the application.
       </p>
 

--- a/www/hunchentoot-doc.html
+++ b/www/hunchentoot-doc.html
@@ -2357,6 +2357,12 @@
         not <a href="#session-too-old-p">too old</a>.  Old sessions
         are <a href="#session-gc">automatically removed</a>.
       </p>
+      <p>
+        Hunchentoot also provides a <code xmlns=""><a href="#session-regenerate-cookie-value">SESSION-REGENERATE-COOKIE-VALUE</a></code>
+        generic function that creates a new cookie value. This helps to prevent
+        against <a href="https://www.owasp.org/index.php/Session_fixation">session fixation
+        attacks</a>, and should be used when a user logs in according to the application.
+      </p>
 
       <p xmlns=""><a class="none" name="session"></a>
       [Standard class]
@@ -2587,6 +2593,16 @@
           The time this session was started.
         </clix:description></blockquote></p>
 
+      <p xmlns=""><a class="none" name="session-regenerate-cookie-value"></a>
+          [Generic function]
+          <br><b>session-regenerate-cookie-value</b> <i><clix:lambda-list xmlns:clix="http://bknr.net/clixdoc">session
+        </clix:lambda-list></i>
+            =&gt;
+            <i><clix:returns xmlns:clix="http://bknr.net/clixdoc">cookie
+        </clix:returns></i><blockquote><clix:description xmlns:clix="http://bknr.net/clixdoc">
+          Regenerates the session cookie value. Because of technical limitations,
+          this function should not be called twice in the same second.
+        </clix:description></blockquote></p>
 
     
 
@@ -4077,6 +4093,9 @@ start and test an https server instead.)
 </li>
 <li>
 <code><a href="#session-max-time">session-max-time</a></code><span class="entry-type">Generic accessor</span>
+</li>
+<li>
+<code><a href="#session-regenerate-cookie-value">session-regenerate-cookie-value</a></code><span class="entry-type">Generic function</span>
 </li>
 <li>
 <code><a href="#session-remote-addr">session-remote-addr</a></code><span class="entry-type">Generic function</span>


### PR DESCRIPTION
Follows up #95 

Open for discussion:

1. function vs method: should this be override-able?
2. The technical limitation of once-per-second.

Revising the 2nd point to remove this limitation would mean going through a randomizer, and if done here, should be done at the existing `initialize-instance` method too, to remain consistent. Another solution would be to use `sb-ext:get-time-of-day` when available? The session id is not changed, so this should be precise enough.

Cheers,
Florian