### PR TITLE
test session cookie validation

### DIFF
--- a/test/script.lisp
+++ b/test/script.lisp
@@ -70,6 +70,13 @@ expecting certain responses."
       (http-assert-body "(?i)\(HUNCHENTOOT-TEST::FOO . &quot;ABC&quot;\)")
       (http-assert-body "(?i)\(HUNCHENTOOT-TEST::BAR . &quot;DEF&quot;\)"))
 
+    (say "Test malformed session cookie validation")
+    (http-request "session.html"
+                  :additional-headers '(("Cookie" . "hunchentoot-session=malformed-session-id")))
+    (http-assert 'status-code 200)
+    ;; session is empty
+    (http-assert-body "(?i)\(HUNCHENTOOT-TEST::FOO\)")
+
     (say "Test GET parameters with foreign characters (Latin-1)")
     (http-request "parameter_latin1_get.html"
                   :external-format-out :iso-8859-1


### PR DESCRIPTION
Related to #101 and #103

These tests shows that solution with &optional do not cover all cases. Now parse-integer fails.
Regular expression in #102 checked for digits only in that part also.
