### PR TITLE
Speed up shutdown and avoid timeout on the listening socket

### DIFF
--- a/acceptor.lisp
+++ b/acceptor.lisp
@@ -335,7 +335,8 @@ they're using secure connections - see the SSL-ACCEPTOR class."))
 
 #-lispworks
 (defun wake-acceptor-for-shutdown (acceptor)
-  "Dials into the accept loop to wake it from select."
+  "Creates a dummy connection to the acceptor, waking ACCEPT-CONNECTIONS while it is waiting.
+This is supposed to force a check of ACCEPTOR-SHUTDOWN-P."
   (handler-case
       (multiple-value-bind (address port) (usocket:get-local-name (acceptor-listen-socket acceptor))
         (let ((conn (usocket:socket-connect address port)))

--- a/acceptor.lisp
+++ b/acceptor.lisp
@@ -315,7 +315,10 @@ they're using secure connections - see the SSL-ACCEPTOR class."))
   acceptor)
 
 (defmethod stop ((acceptor acceptor) &key soft)
-  (setf (acceptor-shutdown-p acceptor) t)
+  (with-lock-held ((acceptor-shutdown-lock acceptor))
+    (setf (acceptor-shutdown-p acceptor) t))
+  #-lispworks
+  (wake-acceptor-for-shutdown acceptor)
   (when soft
     (with-lock-held ((acceptor-shutdown-lock acceptor))
       (when (plusp (accessor-requests-in-progress acceptor))
@@ -329,6 +332,16 @@ they're using secure connections - see the SSL-ACCEPTOR class."))
   #+lispworks
   (mp:process-kill (acceptor-process acceptor))
   acceptor)
+
+#-lispworks
+(defun wake-acceptor-for-shutdown (acceptor)
+  "Dials into the accept loop to wake it from select."
+  (handler-case
+      (multiple-value-bind (address port) (usocket:get-local-name (acceptor-listen-socket acceptor))
+        (let ((conn (usocket:socket-connect address port)))
+          (usocket:socket-close conn)))
+    (error (e)
+      (acceptor-log-message acceptor :error "Wake-for-shutdown connect failed: ~A" e))))
 
 (defmethod initialize-connection-stream ((acceptor acceptor) stream)
  ;; default method does nothing
@@ -550,9 +563,10 @@ catches during request processing."
 (defmethod accept-connections ((acceptor acceptor))
   (usocket:with-server-socket (listener (acceptor-listen-socket acceptor))
     (loop
-     (when (acceptor-shutdown-p acceptor)
-       (return))
-     (when (usocket:wait-for-input listener :ready-only t :timeout +new-connection-wait-time+)
+      (with-lock-held ((acceptor-shutdown-lock acceptor))
+        (when (acceptor-shutdown-p acceptor)
+          (return)))
+      (when (usocket:wait-for-input listener :ready-only t)
        (when-let (client-connection
                   (handler-case (usocket:socket-accept listener)
                     ;; ignore condition

--- a/specials.lisp
+++ b/specials.lisp
@@ -292,11 +292,6 @@ from and writing to a socket stream.")
   "A global lock to prevent two threads from modifying *session-db* at
 the same time \(or NIL for Lisps which don't have threads).")
 
-#-:lispworks
-(defconstant +new-connection-wait-time+ 2
-  "Time in seconds to wait for a new connection to arrive before
-performing a cleanup run.")
-
 (pushnew :hunchentoot *features*)
 
 ;; stuff for Nikodemus Siivola's HYPERDOC

--- a/taskmaster.lisp
+++ b/taskmaster.lisp
@@ -348,10 +348,7 @@ implementations."))
 #-:lispworks
 (defmethod shutdown ((taskmaster one-thread-per-connection-taskmaster))
   ;; just wait until the acceptor process has finished, then return
-  (loop
-   (unless (bt:thread-alive-p (acceptor-process taskmaster))
-     (return))
-   (sleep 1))
+  (bt:join-thread (acceptor-process taskmaster))
   taskmaster)
 
 #-:lispworks


### PR DESCRIPTION
This commit avoids the slow busy wait that enables clean shutdown. It
does this by dialing into the acceptor just after ACCEPTOR-SHUTDOWN-P
has been set to true, waking the accept loop so it can check for
shutdown.

The change makes my tests pass in 0 seconds. It also ensures that
the accept loop doesn't wake up every 2s, conserving precious power for
hunchentoot-powered websites that nobody ever visits.

I haven't tested this with the non-threaded taskmaster yet.