### PR TITLE
Mention license in ASDF, too

### DIFF
--- a/hunchentoot.asd
+++ b/hunchentoot.asd
@@ -40,6 +40,7 @@
   BORDEAUX-THREADS.  It supports HTTP 1.1, serves static files, has a
   simple framework for user-defined handlers and can be extended
   through subclassing."
+  :license "BSD-2-Clause"
   :depends-on (:chunga
                :cl-base64
                :cl-fad


### PR DESCRIPTION
So that `asdf:system-license` can be used.
Thanks a lot!