### PR TITLE
Escape wildcard characters in path names.

### DIFF
--- a/request.lisp
+++ b/request.lisp
@@ -587,7 +587,8 @@ REQUEST."
   any directory traversals or explicit device or host fields.  Returns
   NIL if the path is not acceptable."
   (when (every #'graphic-char-p path)
-    (let* ((pathname (pathname (remove #\\ (regex-replace "^/*" path ""))))
+    (let* ((pathname #+sbcl (sb-ext:parse-native-namestring (remove #\\ (regex-replace "^/*" path "")))
+                     #-sbcl (pathname (remove #\\ (regex-replace "^/*" path ""))))
            (directory (pathname-directory pathname)))
       (when (and (or (null (pathname-host pathname))
                      (equal (pathname-host pathname) (pathname-host *default-pathname-defaults*)))

--- a/request.lisp
+++ b/request.lisp
@@ -587,7 +587,7 @@ REQUEST."
   any directory traversals or explicit device or host fields.  Returns
   NIL if the path is not acceptable."
   (when (every #'graphic-char-p path)
-    (let* ((pathname (make-pathname :name (remove #\\ (regex-replace "^/*" path ""))))
+    (let* ((pathname (pathname (remove #\\ (regex-replace "^/*" path ""))))
            (directory (pathname-directory pathname)))
       (when (and (or (null (pathname-host pathname))
                      (equal (pathname-host pathname) (pathname-host *default-pathname-defaults*)))

--- a/request.lisp
+++ b/request.lisp
@@ -587,7 +587,7 @@ REQUEST."
   any directory traversals or explicit device or host fields.  Returns
   NIL if the path is not acceptable."
   (when (every #'graphic-char-p path)
-    (let* ((pathname (pathname (remove #\\ (regex-replace "^/*" path ""))))
+    (let* ((pathname (make-pathname :name (remove #\\ (regex-replace "^/*" path ""))))
            (directory (pathname-directory pathname)))
       (when (and (or (null (pathname-host pathname))
                      (equal (pathname-host pathname) (pathname-host *default-pathname-defaults*)))


### PR DESCRIPTION
Changed parse-path to use make-pathname for automatic implementation-specific escaping of wildcard characters in path names.

Fixes an issue on SBCL where an unmatched '[' character in the URL causes an Internal Server Error, and if it's matched with a ']' it causes a Not Found. Because SBCL treats un-escaped square brackets in pathnames as wildcards.