### PR TITLE
restore timeout argument when calling usocket:wait-for-input

### DIFF
--- a/acceptor.lisp
+++ b/acceptor.lisp
@@ -573,7 +573,7 @@ catches during request processing."
       (with-lock-held ((acceptor-shutdown-lock acceptor))
         (when (acceptor-shutdown-p acceptor)
           (return)))
-      (when (usocket:wait-for-input listener :ready-only t)
+      (when (usocket:wait-for-input listener :ready-only t :timeout +new-connection-wait-time+)
        (when-let (client-connection
                   (handler-case (usocket:socket-accept listener)
                     ;; ignore condition

--- a/specials.lisp
+++ b/specials.lisp
@@ -292,6 +292,11 @@ from and writing to a socket stream.")
   "A global lock to prevent two threads from modifying *session-db* at
 the same time \(or NIL for Lisps which don't have threads).")
 
+#-:lispworks
+(defconstant +new-connection-wait-time+ 2
+  "Time in seconds to wait for a new connection to arrive before
+performing a cleanup run.")
+
 (pushnew :hunchentoot *features*)
 
 ;; stuff for Nikodemus Siivola's HYPERDOC


### PR DESCRIPTION
Fixes https://github.com/edicl/hunchentoot/issues/129