### PR TITLE
Add in documentation for HUNCHENTOOT:STARTED-P

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -403,6 +403,24 @@
         that will deadlock.
         </clix:description></blockquote></p>
 
+        <p xmlns=""><a class="none" name="started-p"></a>
+          [Generic function]
+          <br><b>started-p</b> <i><clix:lambda-list xmlns:clix="http://bknr.net/clixdoc">acceptor
+        </clix:lambda-list></i>
+            =&gt;
+            <i><clix:returns xmlns:clix="http://bknr.net/clixdoc">generalized-boolean
+            </clix:returns></i><blockquote><clix:description xmlns:clix="http://bknr.net/clixdoc">Tells if <code><i>acceptor</i></code> has been started.
+                The default implementation simply queries <code><i>acceptor</i></code>
+                for its listening status, so if T is returned to the calling thread,
+                then some thread has called <code><a href="#start">start</a></code> or
+                some thread's call to <code><a href="#stop">stop</a></code> hasn't
+                finished. If NIL is returned either some thread has called
+                <code><a href="#stop">stop</a></code>, or some thread's call to
+                <code><a href="#start">start</a></code> hasn't finished or
+                <code><a href="#start">start</a></code> was never called at all for
+                <code><i>acceptor</i></code>.
+        </clix:description></blockquote></p>
+
       <p xmlns=""><a class="none" name="*acceptor*"></a>
       [Special variable]
       <br><b>*acceptor*</b><blockquote><clix:description xmlns:clix="http://bknr.net/clixdoc">The current ACCEPTOR object in the context of a request.

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -368,6 +368,22 @@
         </clix:description>
       </clix:function>
 
+      <clix:function generic='true' name='started-p'>
+        <clix:lambda-list>acceptor
+        </clix:lambda-list>
+        <clix:returns>generalized-boolean
+        </clix:returns>
+        <clix:description>Tells if <clix:arg>acceptor</clix:arg> has been started.
+        The default implementation simply queries <clix:arg>acceptor</clix:arg>
+        for its listening status, so if T is returned to the calling thread, then
+        some thread has called <clix:ref>start</clix:ref> or some thread's call to
+        <clix:ref>stop</clix:ref> hasn't finished. If NIL is returned either some
+        thread has called <clix:ref>stop</clix:ref>, or some thread's call to
+        <clix:ref>start</clix:ref> hasn't finished or <clix:ref>start</clix:ref>
+        was never called at all for <clix:arg>acceptor</clix:arg>.
+        </clix:description>
+      </clix:function>
+
       <clix:special-variable name='*acceptor*'>
         <clix:description>The current ACCEPTOR object in the context of a request.
         </clix:description>


### PR DESCRIPTION
from `acceptor.lisp`
STARTED-P 
```
Tells if ACCEPTOR has been started.                                                                                                                                               
The default implementation simply queries ACCEPTOR for its listening                                                                                                                                 
status, so if T is returned to the calling thread, then some thread                                                                                                                                  
has called START or some thread's call to STOP hasn't finished. If NIL                                                                                                                               
is returned either some thread has called STOP, or some thread's call                                                                                                                                
to START hasn't finished or START was never called at all for                                                                                                                                        
ACCEPTOR.
```