### PR TITLE
Doc: add frameworks, typos

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -305,9 +305,12 @@
     </p>
     <ul>
       <li>
-        <a href="http://weblocks-framework.info/">Weblocks</a> by
-        Slava Akhmechet is a "continuations-based web framework" which
-        is based on Hunchentoot.
+        <a href="http://40ants.com/weblocks/">Weblocks</a>
+        is an isomorphic web framework, based on Hunchentoot.
+      </li>
+      <li>
+        <a href="https://github.com/fukamachi/clack">Clack</a> is a
+        web server abstraction layer, defaulting to Hunchentoot.
       </li>
       <li>
         <a href="https://github.com/slyrus/hunchentoot-cgi">hunchentoot-cgi</a>
@@ -320,9 +323,11 @@
         server based on Hunchentoot.
       </li>
       <li>
-        <a href="http://restas.lisper.ru/">RESTAS</a> is a web
-        framework based on Hunchentoot.
+        <a href="https://github.com/fukamachi/caveman">Caveman</a>, <a href="https://github.com/Shirakumo/radiance">Radiance</a>, <a href="https://github.com/joaotavora/snooze">Snooze</a> or
+        <a href="http://restas.lisper.ru/">RESTAS</a> are web
+        frameworks based on Hunchentoot.
       </li>
+
     </ul>
   
 

--- a/www/hunchentoot-doc.html
+++ b/www/hunchentoot-doc.html
@@ -305,6 +305,10 @@
     </p>
     <ul>
       <li>
+        <a href="https://github.com/fukamachi/clack">Clack</a> is a
+        web server abstraction layer, defaulting to Hunchentoot.
+      </li>
+      <li>
         <a href="http://weblocks-framework.info/">Weblocks</a> by
         Slava Akhmechet is a "continuations-based web framework" which
         is based on Hunchentoot.
@@ -320,8 +324,9 @@
         server based on Hunchentoot.
       </li>
       <li>
-        <a href="http://restas.lisper.ru/">RESTAS</a> is a web
-        framework based on Hunchentoot.
+        <a href="https://github.com/fukamachi/caveman">Caveman</a>, <a href="https://github.com/Shirakumo/radiance">Radiance</a>, <a href="https://github.com/joaotavora/snooze">Snooze</a> or
+        <a href="http://restas.lisper.ru/">RESTAS</a> are web
+        frameworks based on Hunchentoot.
       </li>
     </ul>
   

--- a/www/hunchentoot-doc.html
+++ b/www/hunchentoot-doc.html
@@ -288,7 +288,8 @@
     the things you can do with Hunchentoot.  To start the example
     website, enter the following code into your listener:
 
-<pre>(<a class="noborder" href="http://common-lisp.net/~mmommer/asdf-howto.shtml#sec11">asdf:oos</a> 'asdf:load-op :hunchentoot-test)</pre>
+<pre>(ql:quickload "Hunchentoot-test")
+(<a class="noborder" href="http://common-lisp.net/~mmommer/asdf-howto.shtml#sec11">asdf:oos</a> 'asdf:load-op :hunchentoot-test)</pre>
 
     Now go to "<a href="http://127.0.0.1:4242/hunchentoot/test"><code>http://127.0.0.1:4242/hunchentoot/test</code></a>" and play a bit.
     </p>

--- a/www/hunchentoot-doc.html
+++ b/www/hunchentoot-doc.html
@@ -339,7 +339,7 @@
       If you want Hunchentoot to actually do something, you have to create and
       <a href="#teen-age">start</a> an <a href="#acceptor">acceptor</a>.
       You can also run several acceptors in one image, each one
-      listening on a different different port.
+      listening on a different port.
 
       <p xmlns=""><a class="none" name="acceptor"></a>
       [Standard class]


### PR DESCRIPTION
Hi,

Restas was lonely, I added some friends.

fixed Weblock's url to the active fork,

hunchentoot-test example was missing cl-who,

small typo.

I'm confused about `www/hunchentoot-doc.html` and `doc/index.html` though, why are both version controlled ?

Regards