### PR TITLE
doc: reword frameworks not *based* on Hunchentoot

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -305,10 +305,6 @@
     </p>
     <ul>
       <li>
-        <a href="http://40ants.com/weblocks/">Weblocks</a>
-        is an isomorphic web framework, based on Hunchentoot.
-      </li>
-      <li>
         <a href="https://github.com/fukamachi/clack">Clack</a> is a
         web server abstraction layer, defaulting to Hunchentoot.
       </li>
@@ -323,13 +319,16 @@
         server based on Hunchentoot.
       </li>
       <li>
-        <a href="https://github.com/fukamachi/caveman">Caveman</a>, <a href="https://github.com/Shirakumo/radiance">Radiance</a>, <a href="https://github.com/joaotavora/snooze">Snooze</a> or
-        <a href="http://restas.lisper.ru/">RESTAS</a> are web
-        frameworks based on Hunchentoot.
+        <a href="http://restas.lisper.ru/">RESTAS</a> is a web
+        framework based on Hunchentoot.
+        <a href="https://github.com/fukamachi/caveman">Caveman</a>, <a href="https://github.com/Shirakumo/radiance">Radiance</a>, <a href="https://github.com/joaotavora/snooze">Snooze</a>
+        or again <a href="http://40ants.com/weblocks/">Weblocks</a>
+        are frameworks compatible with it.
+
       </li>
 
     </ul>
-  
+
 
   <h3 xmlns=""><a class="none" name="reference">Function and variable reference</a></h3>
 

--- a/www/hunchentoot-doc.html
+++ b/www/hunchentoot-doc.html
@@ -310,11 +310,6 @@
         web server abstraction layer, defaulting to Hunchentoot.
       </li>
       <li>
-        <a href="http://weblocks-framework.info/">Weblocks</a> by
-        Slava Akhmechet is a "continuations-based web framework" which
-        is based on Hunchentoot.
-      </li>
-      <li>
         <a href="https://github.com/slyrus/hunchentoot-cgi">hunchentoot-cgi</a>
         (by Cyrus Harmon) provides
         <a href="http://en.wikipedia.org/wiki/Common_Gateway_Interface">CGI</a>
@@ -325,12 +320,14 @@
         server based on Hunchentoot.
       </li>
       <li>
-        <a href="https://github.com/fukamachi/caveman">Caveman</a>, <a href="https://github.com/Shirakumo/radiance">Radiance</a>, <a href="https://github.com/joaotavora/snooze">Snooze</a> or
-        <a href="http://restas.lisper.ru/">RESTAS</a> are web
-        frameworks based on Hunchentoot.
-      </li>
+        <a href="http://restas.lisper.ru/">RESTAS</a> is a web
+        framework based on Hunchentoot.
+        <a href="https://github.com/fukamachi/caveman">Caveman</a>, <a href="https://github.com/Shirakumo/radiance">Radiance</a>, <a href="https://github.com/joaotavora/snooze">Snooze</a>
+        or again <a href="http://40ants.com/weblocks/">Weblocks</a>
+        are frameworks compatible with it.
+
     </ul>
-  
+
 
   <h3 xmlns=""><a class="none" name="reference">Function and variable reference</a></h3>
 


### PR DESCRIPTION
fixes #152 

@joaotavora I reworded with

>  RESTAS is a web framework based on Hunchentoot. Caveman, Radiance, Snooze or again Weblocks are frameworks compatible with it. 

Hope that'll do. Nice catch btw.