### PR TITLE
Typo fix, and do ignore _all_ errors like the comment says.

### DIFF
--- a/acceptor.lisp
+++ b/acceptor.lisp
@@ -484,9 +484,9 @@ chunked encoding, but acceptor is configured to not use it.")))))
                  ;; as we are at the end of the request here, we ignore all
                  ;; errors that may occur while flushing and/or closing the
                  ;; stream.
-                 (ignore-errors*
+                 (ignore-errors
                   (finish-output stream))
-                 (ignore-errors*
+                 (ignore-errors
                   (close stream :abort t))))
           (unless (or (not *hunchentoot-stream*)
                       (eql socket-stream *hunchentoot-stream*))

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -298,7 +298,7 @@
       If you want Hunchentoot to actually do something, you have to create and
       <a href="#teen-age">start</a> an <a href="#acceptor">acceptor</a>.
       You can also run several acceptors in one image, each one
-      listening on a different different port.
+      listening on a different port.
 
       <clix:class name='acceptor'>
         <clix:description>


### PR DESCRIPTION
While the first patch is a no-brainer, I'm not 100% sure about the second one.

The comment explains the intention - but `IGNORE-ERRORS*` doesn't provide that, eg. using `sslscan` against HT causes errors that are not caught. So my proposal is to switch to `IGNORE-ERRORS` instead, which works as described.