### PR TITLE
Don't error - warn - on timeouts for clasp

### DIFF
--- a/set-timeouts.lisp
+++ b/set-timeouts.lisp
@@ -80,6 +80,8 @@ set."
   #+:abcl
   (when write-timeout
     (warn "Unimplemented."))
-  #-(or :clisp :allegro :openmcl :sbcl :lispworks :cmu :ecl :abcl)
+  #+:clasp
+  (warn "set-timeouts unimplemented.")
+  #-(or :clisp :allegro :openmcl :sbcl :lispworks :cmu :ecl :abcl :clasp)
   (not-implemented 'set-timeouts))
 


### PR DESCRIPTION
hunchentoot works fine in clasp, just the timeouts are not yet implemented. Just emit a warning until timeouts are implemented

