### PR TITLE
Removed a bug which arises when pages which were defined with accesso…

### DIFF
--- a/easy-handlers.lisp
+++ b/easy-handlers.lisp
@@ -293,7 +293,7 @@ argument is provided."
     `(progn
        ,@(when uri
            (list
-            (once-only (uri host)
+            (once-only (uri host acceptor-names)
               `(progn
                  (setq *easy-handler-alist*
                        (delete-if (lambda (list)
@@ -302,6 +302,7 @@ argument is provided."
                                                       `(string= ,host (fourth list))))
                                              (eq ',name (third list)))
                                          (or (eq ,acceptor-names t)
+                                             (eq (second list) t)
                                              (intersection ,acceptor-names
                                                            (second list)))))
                                   *easy-handler-alist*))


### PR DESCRIPTION
…r-names T are redefined to include only some accessor-names.

For example:
(define-easy-handler (test-page :uri "/test") ())
(define-easy-handler (test-page :uri "/test" :acceptor-names '(TEST)) ())
Instead of throwing an error, the second definition now simply overrides the first.