### PR TITLE
Respect the "Content-Length" header when parsing form data.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2019-05-22
+Respect the "Content-Length" header when parsing POST parameters
 Version 1.2.38
 2017-12-03
 Better pathname validation.

--- a/request.lisp
+++ b/request.lisp
@@ -268,7 +268,12 @@ slot values are computed in this :AFTER method."
 content type has already been verified.  Returns the form data as
 alist or NIL if there was no data or the data could not be parsed."
   (handler-case*
-      (let ((content-stream (make-flexi-stream (content-stream request) :external-format +latin-1+)))
+      (let* ((content-length (header-in :content-length request))
+             (content-stream (make-flexi-stream (content-stream request)
+                                               :external-format +latin-1+
+                                               :bound (if content-length 
+                                                        (parse-integer content-length 
+                                                                       :junk-allowed T)))))
         (prog1
             (parse-rfc2388-form-data content-stream (header-in :content-type request) external-format)
           (let ((stray-data (get-post-data :already-read (flexi-stream-position content-stream))))


### PR DESCRIPTION
This is a plain bugfix.

Another (related) point is a (potential) client bug as well, but we might want to fix that in hunchentoot:
When trying to upload a file that you don't have access rights for, firefox happily goes ahead and sends a request with "Content-length: 0" and some mime boundary header but then no actual post data (as there's no content to send), resulting in (with the patch above) an EOF error.
(Without the patch, the server thread runs into a TCP timeout, as it waits for the never-sent mime boundary.)

```
end of file on #<FLEXI-STREAMS:FLEXI-IO-STREAM {100BF9FC23}>
   [Condition of type END-OF-FILE]

Frames:
  0.  (READ-CHAR #<FLEXI-STREAMS:FLEXI-IO-STREAM {100BF9FC23}> T NIL #<unused argument>)
  1.  ((FLET RFC2388::RUN :IN RFC2388::READ-UNTIL-NEXT-BOUNDARY) #<BROADCAST-STREAM {10000321A3}>)
  2.  (RFC2388::READ-UNTIL-NEXT-BOUNDARY #<FLEXI-STREAMS:FLEXI-IO-STREAM {100BF9FC23}> "---------------------------129268202915739752981342792626" T NIL)
  3.  ((:METHOD RFC2388:PARSE-MIME (STREAM T)) #<FLEXI-STREAMS:FLEXI-IO-STREAM {100BF9FC23}> "---------------------------129268202915739752981342792626" :WRITE-CONTENT-TO-FILE T) [fast-method]
  4.  ((SB-PCL::EMF RFC2388:PARSE-MIME) #<unused argument> #<unused argument> #<FLEXI-STREAMS:FLEXI-IO-STREAM {100BF9FC23}> "---------------------------129268202915739752981342792626")
  5.  (HUNCHENTOOT::PARSE-RFC2388-FORM-DATA #<FLEXI-STREAMS:FLEXI-IO-STREAM {100BF9FC23}> "multipart/form-data; boundary=---------------------------129268202915739752981342792626" #<FLEXI-STREAMS::FLEXI-UTF..
  6.  ((FLET "FORM-FUN-4" :IN HUNCHENTOOT::PARSE-MULTIPART-FORM-DATA))
  7.  (HUNCHENTOOT::PARSE-MULTIPART-FORM-DATA #<HUNCHENTOOT:REQUEST {100BF9C0B3}> #<FLEXI-STREAMS::FLEXI-UTF-8-FORMAT (:UTF-8 :EOL-STYLE :LF) {10034A0AC3}>)
  8.  ((FLET "FORM-FUN-7" :IN HUNCHENTOOT::MAYBE-READ-POST-PARAMETERS))
  9.  (HUNCHENTOOT::MAYBE-READ-POST-PARAMETERS :REQUEST #<HUNCHENTOOT:REQUEST {100BF9C0B3}> :FORCE T :EXTERNAL-FORMAT NIL)
  10. ((:METHOD HUNCHENTOOT:POST-PARAMETERS :BEFORE (HUNCHENTOOT:REQUEST)) #<HUNCHENTOOT:REQUEST {100BF9C0B3}>) [fast-method]
  11. ((SB-PCL::EMF HUNCHENTOOT:POST-PARAMETERS) #<unused argument> #<unused argument> #<HUNCHENTOOT:REQUEST {100BF9C0B3}>)
  12. (HUNCHENTOOT:POST-PARAMETER "file" #<HUNCHENTOOT:REQUEST {100BF9C0B3}>)
```

I'm not sure about the correct way to handle that --

* should we just fail the complete request at some higher level (is "Content-length: 0" invalid?),
* should we fail _only_ when arguments are being requested (as it seems to be now), or
* should we return `NIL` for this parameter only (as this parameter was never sent) and not fail?

