### PR TITLE
get-request-data: detect malformed request line better

### DIFF
--- a/headers.lisp
+++ b/headers.lisp
@@ -269,8 +269,9 @@ protocol of the request."
            (send-bad-request-response stream)
            (return-from get-request-data nil))
          (unless protocol
-           (send-bad-request-response stream)
-           (return-from get-request-data nil))
+           ;; HTTP/1.1 specifies that if protocol is not provided
+           ;; then assume protocol version to be 1.0
+           (setf protocol "HTTP/1.0")
          (unless (member protocol +valid-protocol-versions+ :test #'string=)
            (send-unknown-protocol-response stream)
            (return-from get-request-data nil))

--- a/headers.lisp
+++ b/headers.lisp
@@ -272,6 +272,7 @@ protocol of the request."
            ;; HTTP/1.1 specifies that if protocol is not provided
            ;; then assume protocol version to be 1.0
            (setf protocol "HTTP/1.0")
+         (setf protocol (trim-whitespace protocol))
          (unless (member protocol +valid-protocol-versions+ :test #'string=)
            (send-unknown-protocol-response stream)
            (return-from get-request-data nil))
@@ -296,6 +297,4 @@ protocol of the request."
            (values headers
                    (as-keyword method)
                    url-string
-                   (if protocol
-                       (as-keyword (trim-whitespace protocol))
-                       :http/0.9))))))))
+                   (as-keyword protocol))))))))

--- a/headers.lisp
+++ b/headers.lisp
@@ -271,7 +271,7 @@ protocol of the request."
          (unless protocol
            ;; HTTP/1.1 specifies that if protocol is not provided
            ;; then assume protocol version to be 1.0
-           (setf protocol "HTTP/1.0")
+           (setf protocol "HTTP/1.0"))
          (setf protocol (trim-whitespace protocol))
          (unless (member protocol +valid-protocol-versions+ :test #'string=)
            (send-unknown-protocol-response stream)

--- a/headers.lisp
+++ b/headers.lisp
@@ -246,9 +246,9 @@ not want to wait for another request any longer."
 (defun printable-ascii-char-p (char)
   (<= 32 (char-code char) 126))
 
-(defconstant +valid-request-methods+ '(("GET" . #:get) ("POST" . #:post) ("PUT" . #:put) ("DELETE" . #:delete) ("CONNECT" . #:connect) ("OPTIONS" . #:options) ("TRACE" . #:trace) ("PATCH" . #:patch)))
+(defconstant +valid-request-methods+ '(("GET" . :get) ("POST" . :post) ("PUT" . :put) ("DELETE" . :delete) ("CONNECT" . :connect) ("OPTIONS" . :options) ("TRACE" . :trace) ("PATCH" . :patch)))
 
-(defconstant +valid-protocol-versions+ '(("HTTP/1.0" . #:http/1.0) ("HTTP/1.1" . #:http/1.1)))
+(defconstant +valid-protocol-versions+ '(("HTTP/1.0" . :http/1.0) ("HTTP/1.1" . :http/1.1)))
 
 (defun get-request-data (stream)
   "Reads incoming headers from the client via STREAM.  Returns as

--- a/test/script-engine.lisp
+++ b/test/script-engine.lisp
@@ -158,7 +158,7 @@ from the expansion environment."
 
 (defun http-request (url
                      &rest args
-                     &key (protocol :http/1.1)
+                     &key (protocol :http/1.0)
                           (method :get)
                           content
                           content-type


### PR DESCRIPTION
and also detect if request protocol is unsupported.