### PR TITLE
Clarify documentation for DETACH-SOCKET

### DIFF
--- a/docs/index.xml
+++ b/docs/index.xml
@@ -673,7 +673,7 @@
       <clix:function generic='true' name='detach-socket'>
         <clix:lambda-list>acceptor
         </clix:lambda-list>
-        <clix:returns>stream
+        <clix:returns>nil
         </clix:returns>
         <clix:description>
           Indicate to Hunchentoot that it should stop serving requests


### PR DESCRIPTION
`DETACH-SOCKET` returns `NIL`, not the socket stream as might have been implied by the documented function signature.