### PR TITLE
Allow for overriding get-backtrace

### DIFF
--- a/acceptor.lisp
+++ b/acceptor.lisp
@@ -667,9 +667,18 @@ handler."
                     (when *headers-sent*
                       (setq *finish-processing-socket* t))
                     (throw 'handler-done
-                      (values nil cond (get-backtrace))))))
+                      (values nil cond (get-backtrace-for-acceptor *acceptor*))))))
     (with-debugger
       (acceptor-dispatch-request *acceptor* *request*))))
+
+(defgeneric get-backtrace-for-acceptor (acceptor)
+  (:documentation
+   "A method that allows for overriding how the stack trace is
+displayed or logged. The default stacktrace might be verbose on some
+Lisps, which might write sensitive information, such as passwords."))
+
+(defmethod get-backtrace-for-acceptor (acceptor)
+  (get-backtrace))
 
 (defgeneric acceptor-status-message (acceptor http-status-code &key &allow-other-keys)
   (:documentation


### PR DESCRIPTION
On Lispworks, the default trivial-backtrace output is super verbose, with all the variables displayed. Now this is fine for development, but on production this is is still logged to stdout even if it isn't show to users. This can cause two things: a) it makes my logs grow fast if there's an error, and b) it might log sensitive information to disk in clear text.

This PR just allows that to be overriden. It doesn't change the default behavior. My intended use is to override this just in production to only log the backtrace without the bindings. Perhaps even do more complicated things like remove specific bindings from the output.