### PR TITLE
discard multiple values returned by handle-request

### DIFF
--- a/request.lisp
+++ b/request.lisp
@@ -238,7 +238,7 @@ slot values are computed in this :AFTER method."
                    ;; skip dispatch if bad request
                    (when (eql (return-code *reply*) +http-ok+)
                      (catch 'handler-done
-                       (handle-request *acceptor* *request*)))
+                       (values (handle-request *acceptor* *request*))))
                  (when error
                    ;; error occurred in request handler
                    (report-error-to-client error backtrace))


### PR DESCRIPTION
In default method for `handler-request'

```
(throw 'handler-done
   (values nil cond (get-backtrace)))
```

is used, which is caught in `process-request' and the second return
value is used as error flag. However if handler-request returns
multiple values normally from user code, this also registers as
error.

For example, a define-easy-handler such as

```
(define-easy-handler (...) ()
    ...
    (gethash key table))
```

seems OK as user code. But the `gethash' returns T as second value
which undesirably leads to error.