### PR TITLE
add SameSite cookie attribute

### DIFF
--- a/cookie.lisp
+++ b/cookie.lisp
@@ -123,13 +123,13 @@ replaced."
   "Converts the COOKIE object COOKIE to a string suitable for a
 'Set-Cookie' header to be sent to the client."
   (format nil
-          "~A=~A~@[; Expires=~A~]~@[; Max-Age=~A~]~@[; Domain=~A~]~@[; Path=~A~]~:[~;; Secure~]~:[~;; HttpOnly~]"
+          "~A=~A~@[; Expires=~A~]~@[; Max-Age=~A~]~@[; Domain=~A~]~@[; Path=~A~]~:[~;; Secure~]~:[~;; HttpOnly~];SameSite=~A"
           (cookie-name cookie)
           (cookie-value cookie)
           (cookie-date (cookie-expires cookie))
           (cookie-max-age cookie)
           (cookie-domain cookie)
           (cookie-path cookie)
-          (cookie-same-site cookie)
           (cookie-secure cookie)
-          (cookie-http-only cookie)))
+          (cookie-http-only cookie)
+          (cookie-same-site cookie)))

--- a/cookie.lisp
+++ b/cookie.lisp
@@ -60,13 +60,13 @@ cookie expires \(or NIL).")
            :initform "None"
            :accessor cookie-same-site
            :documentation "The SameSite attribute for the cookie, needs
-to be one of \"None\", \"Lax\" or \"Strict\". See 
+to be one of \"None\", \"Lax\" or \"Strict\". Defaults to \"None\". See
 <https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-02#section-5.3.7>.")
    (secure :initarg :secure
            :initform nil
            :accessor cookie-secure
            :documentation "A generalized boolean denoting whether this
-cookie is a secure cookie.")   
+cookie is a secure cookie.")
    (http-only :initarg :http-only
               :initform nil
               :accessor cookie-http-only
@@ -97,7 +97,7 @@ REPLY object REPLY. If a cookie with the same name
         (push (cons name cookie) (cookies-out reply))
         cookie))))
 
-(defun set-cookie (name &key (value "") expires max-age path domain same-site secure http-only (reply *reply*))
+(defun set-cookie (name &key (value "") expires max-age path domain (same-site "None") secure http-only (reply *reply*))
   "Creates a cookie object from the parameters provided and adds
 it to the outgoing cookies of the REPLY object REPLY. If a cookie
 with the name NAME \(case-sensitive) already exists, it is

--- a/cookie.lisp
+++ b/cookie.lisp
@@ -56,11 +56,17 @@ cookie expires \(or NIL).")
            :initform nil
            :accessor cookie-domain
            :documentation "The domain this cookie is valid for \(or NIL).")
+   (same-site :initarg :same-site
+           :initform "None"
+           :accessor cookie-same-site
+           :documentation "The SameSite attribute for the cookie, needs
+to be one of \"None\", \"Lax\" or \"Strict\". See 
+<https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-02#section-5.3.7>.")
    (secure :initarg :secure
            :initform nil
            :accessor cookie-secure
            :documentation "A generalized boolean denoting whether this
-cookie is a secure cookie.")
+cookie is a secure cookie.")   
    (http-only :initarg :http-only
               :initform nil
               :accessor cookie-http-only
@@ -91,7 +97,7 @@ REPLY object REPLY. If a cookie with the same name
         (push (cons name cookie) (cookies-out reply))
         cookie))))
 
-(defun set-cookie (name &key (value "") expires max-age path domain secure http-only (reply *reply*))
+(defun set-cookie (name &key (value "") expires max-age path domain same-site secure http-only (reply *reply*))
   "Creates a cookie object from the parameters provided and adds
 it to the outgoing cookies of the REPLY object REPLY. If a cookie
 with the name NAME \(case-sensitive) already exists, it is
@@ -103,6 +109,7 @@ replaced."
                               :max-age max-age
                               :path path
                               :domain domain
+                              :same-site same-site
                               :secure secure
                               :http-only http-only)
                reply))
@@ -123,5 +130,6 @@ replaced."
           (cookie-max-age cookie)
           (cookie-domain cookie)
           (cookie-path cookie)
+          (cookie-same-site cookie)
           (cookie-secure cookie)
           (cookie-http-only cookie)))

--- a/cookie.lisp
+++ b/cookie.lisp
@@ -57,7 +57,7 @@ cookie expires \(or NIL).")
            :accessor cookie-domain
            :documentation "The domain this cookie is valid for \(or NIL).")
    (same-site :initarg :same-site
-           :initform "None"
+           :initform nil
            :accessor cookie-same-site
            :documentation "The SameSite attribute for the cookie, needs
 to be one of \"None\", \"Lax\" or \"Strict\". Defaults to \"None\". See
@@ -97,7 +97,7 @@ REPLY object REPLY. If a cookie with the same name
         (push (cons name cookie) (cookies-out reply))
         cookie))))
 
-(defun set-cookie (name &key (value "") expires max-age path domain (same-site "None") secure http-only (reply *reply*))
+(defun set-cookie (name &key (value "") expires max-age path domain same-site secure http-only (reply *reply*))
   "Creates a cookie object from the parameters provided and adds
 it to the outgoing cookies of the REPLY object REPLY. If a cookie
 with the name NAME \(case-sensitive) already exists, it is
@@ -123,7 +123,7 @@ replaced."
   "Converts the COOKIE object COOKIE to a string suitable for a
 'Set-Cookie' header to be sent to the client."
   (format nil
-          "~A=~A~@[; Expires=~A~]~@[; Max-Age=~A~]~@[; Domain=~A~]~@[; Path=~A~];SameSite=~A~:[~;; Secure~]~:[~;; HttpOnly~]"
+          "~A=~A~@[; Expires=~A~]~@[; Max-Age=~A~]~@[; Domain=~A~]~@[; Path=~A~]~@[; SameSite=~A~]~:[~;; Secure~]~:[~;; HttpOnly~]"
           (cookie-name cookie)
           (cookie-value cookie)
           (cookie-date (cookie-expires cookie))

--- a/cookie.lisp
+++ b/cookie.lisp
@@ -123,13 +123,13 @@ replaced."
   "Converts the COOKIE object COOKIE to a string suitable for a
 'Set-Cookie' header to be sent to the client."
   (format nil
-          "~A=~A~@[; Expires=~A~]~@[; Max-Age=~A~]~@[; Domain=~A~]~@[; Path=~A~]~:[~;; Secure~]~:[~;; HttpOnly~];SameSite=~A"
+          "~A=~A~@[; Expires=~A~]~@[; Max-Age=~A~]~@[; Domain=~A~]~@[; Path=~A~];SameSite=~A~:[~;; Secure~]~:[~;; HttpOnly~]"
           (cookie-name cookie)
           (cookie-value cookie)
           (cookie-date (cookie-expires cookie))
           (cookie-max-age cookie)
           (cookie-domain cookie)
           (cookie-path cookie)
+          (cookie-same-site cookie)
           (cookie-secure cookie)
-          (cookie-http-only cookie)
-          (cookie-same-site cookie)))
+          (cookie-http-only cookie)))


### PR DESCRIPTION
this allows to set the `SameSite` attribute for a cookie, as explained in more details at
- https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-02#section-5.3.7
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie (Cmd-F "SameSite").