### PR TITLE
rewrite system definitions for simplicity, style and to avoid warnings

### DIFF
--- a/hunchentoot.asd
+++ b/hunchentoot.asd
@@ -26,14 +26,7 @@
 ;;; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-(in-package :cl-user)
-
-(defpackage :hunchentoot-asd
-  (:use :cl :asdf))
-
-(in-package :hunchentoot-asd)
-
-(defsystem :hunchentoot
+(defsystem "hunchentoot"
   :serial t
   :version "1.3.0"
   :description "Hunchentoot is a HTTP server based on USOCKET and
@@ -41,19 +34,20 @@
   simple framework for user-defined handlers and can be extended
   through subclassing."
   :license "BSD-2-Clause"
-  :depends-on (:chunga
-               :cl-base64
-               :cl-fad
-               :cl-ppcre
-               :flexi-streams
-               #-(or :lispworks :hunchentoot-no-ssl) :cl+ssl
-               :md5
-               :alexandria
-               :rfc2388
-               :trivial-backtrace
-               #-:lispworks :usocket
-               #-:lispworks :bordeaux-threads)
-  :components ((:module url-rewrite
+  :depends-on ("chunga"
+               "cl-base64"
+               "cl-fad"
+               "cl-ppcre"
+               "flexi-streams"
+               (:feature (:not (:or :lispworks :hunchentoot-no-ssl))
+                         "cl+ssl")
+               "md5"
+               "alexandria"
+               "rfc2388"
+               "trivial-backtrace"
+               (:feature (:not :lispworks) "usocket")
+               (:feature (:not :lispworks) "bordeaux-threads"))
+  :components ((:module "url-rewrite"
                 :serial t
                 :components ((:file "packages")
                              (:file "specials")
@@ -61,8 +55,8 @@
                              (:file "util")
                              (:file "url-rewrite")))
                (:file "packages")
-               #+:lispworks (:file "lispworks")
-               #-:lispworks (:file "compat")
+               (:file "lispworks" :if-feature :lispworks)
+               (:file "compat" :if-feature (:not :lispworks))
                (:file "specials")
                (:file "conditions")
                (:file "mime-types")
@@ -77,10 +71,11 @@
                (:file "set-timeouts")
                (:file "taskmaster")
                (:file "acceptor")
-               #-:hunchentoot-no-ssl (:file "ssl")
-               (:file "easy-handlers")))
+               (:file "ssl" :if-feature (:not :hunchentoot-no-ssl))
+               (:file "easy-handlers"))
+  :perform (test-op (o c) (load (merge-pathnames "run-test.lisp" (system-source-directory c)))))
 
-(defsystem :hunchentoot-test
+(defsystem "hunchentoot/test"
   :description "Self test functionality for the Hunchentoot HTTP server."
   :components ((:module "test"
                         :serial t
@@ -88,16 +83,13 @@
                                      (:file "test-handlers")
                                      (:file "script-engine")
                                      (:file "script"))))
-  :depends-on (:hunchentoot :cl-who :cl-ppcre :drakma))
+  :depends-on ("hunchentoot" "cl-who" "cl-ppcre" "drakma"))
 
-(defmethod perform ((o test-op) (c (eql (find-system 'hunchentoot))))
-  (load (merge-pathnames "run-test.lisp" (system-source-directory c))))
-
-(defsystem :hunchentoot-dev
+(defsystem "hunchentoot/dev"
     :description "Development tools for Hunchentoot development and releases"
     :components ((:file "make-docstrings"))
-    :depends-on (:hunchentoot
-                 :hunchentoot-test
-                 :xpath
-                 :cxml-stp
-                 :swank))
+    :depends-on ("hunchentoot"
+                 "hunchentoot/test"
+                 "xpath"
+                 "cxml-stp"
+                 "swank"))

--- a/hunchentoot.asd
+++ b/hunchentoot.asd
@@ -26,7 +26,7 @@
 ;;; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-(defsystem "hunchentoot"
+(defsystem :hunchentoot
   :serial t
   :version "1.3.0"
   :description "Hunchentoot is a HTTP server based on USOCKET and
@@ -34,19 +34,19 @@
   simple framework for user-defined handlers and can be extended
   through subclassing."
   :license "BSD-2-Clause"
-  :depends-on ("chunga"
-               "cl-base64"
-               "cl-fad"
-               "cl-ppcre"
-               "flexi-streams"
+  :depends-on (:chunga
+               :cl-base64
+               :cl-fad
+               :cl-ppcre
+               :flexi-streams
                (:feature (:not (:or :lispworks :hunchentoot-no-ssl))
-                         "cl+ssl")
-               "md5"
-               "alexandria"
-               "rfc2388"
-               "trivial-backtrace"
-               (:feature (:not :lispworks) "usocket")
-               (:feature (:not :lispworks) "bordeaux-threads"))
+                         :cl+ssl)
+               :md5
+               :alexandria
+               :rfc2388
+               :trivial-backtrace
+               (:feature (:not :lispworks) :usocket)
+               (:feature (:not :lispworks) :bordeaux-threads))
   :components ((:module "url-rewrite"
                 :serial t
                 :components ((:file "packages")
@@ -75,7 +75,7 @@
                (:file "easy-handlers"))
   :perform (test-op (o c) (load (merge-pathnames "run-test.lisp" (system-source-directory c)))))
 
-(defsystem "hunchentoot/test"
+(defsystem :hunchentoot/test
   :description "Self test functionality for the Hunchentoot HTTP server."
   :components ((:module "test"
                         :serial t
@@ -83,13 +83,13 @@
                                      (:file "test-handlers")
                                      (:file "script-engine")
                                      (:file "script"))))
-  :depends-on ("hunchentoot" "cl-who" "cl-ppcre" "drakma"))
+  :depends-on (:hunchentoot :cl-who :cl-ppcre :drakma))
 
-(defsystem "hunchentoot/dev"
-    :description "Development tools for Hunchentoot development and releases"
-    :components ((:file "make-docstrings"))
-    :depends-on ("hunchentoot"
-                 "hunchentoot/test"
-                 "xpath"
-                 "cxml-stp"
-                 "swank"))
+(defsystem :hunchentoot/dev
+  :description "Development tools for Hunchentoot development and releases"
+  :components ((:file "make-docstrings"))
+  :depends-on (:hunchentoot
+               :hunchentoot/test
+               :xpath
+               :cxml-stp
+               :swank))

--- a/run-test.lisp
+++ b/run-test.lisp
@@ -30,7 +30,7 @@
 
 (defparameter *test-port* 4241)
 
-(asdf:oos 'asdf:load-op :hunchentoot-test)
+(asdf:oos 'asdf:load-op "hunchentoot/test")
 
 (defun run-tests ()
   (format t "~&;; Starting web server on localhost:~A." *test-port*)


### PR DESCRIPTION
I've tested that it behaves the way I expect on my SBCL-macos-arm64 system, but I don't have access to Lispworks, Windows, or a bunch of other combinations, so I'd greatly appreciate sanity checks from anyone who does before I merge.