### PR TITLE
Document *SHOW-LISP-ERRORS-P* required for custom error template directory

### DIFF
--- a/acceptor.lisp
+++ b/acceptor.lisp
@@ -165,7 +165,7 @@ stream or to NIL to suppress logging.")
  messages.  Files must be named <return-code>.html with <return-code>
  representing the HTTP return code that the file applies to,
  i.e. 404.html would be used as the content for a HTTP 404 Not found
- response.")
+ response. Set *SHOW-LISP-ERRORS-P* to T for this setting to work.")
    (document-root :initarg :document-root
                   :accessor acceptor-document-root
                   :documentation "Directory pathname that points to


### PR DESCRIPTION
for https://github.com/edicl/hunchentoot/issues/112

While Google exists, this setting is required and not documented, so this PR could save a couple hours to future developers. 