### PR TITLE
Chore: stop to :use packages

### DIFF
--- a/easy-handlers.lisp
+++ b/easy-handlers.lisp
@@ -57,7 +57,7 @@ NIL unconditionally."
     (character (and (= (length argument) 1)
                     (char argument 0)))
     (integer (ignore-errors* (parse-integer argument :junk-allowed t)))
-    (keyword (as-keyword argument :destructivep nil))
+    (keyword (chunga:as-keyword argument :destructivep nil))
     (boolean t)
     (otherwise (funcall type argument))))
 
@@ -83,7 +83,7 @@ is the corresponding value."
   #+:sbcl (declare (sb-ext:muffle-conditions warning))
   (let* ((index-value-list
           (loop for (full-name . value) in parameters
-                for index = (register-groups-bind (name index-string)
+                for index = (ppcre:register-groups-bind (name index-string)
                                 ("^(.*)\\[(\\d+)\\]$" full-name)
                               (when (string= name parameter-name)
                                 (parse-integer index-string)))
@@ -106,7 +106,7 @@ corresponding value is associated with the key FOO \(converted to
 KEY-TYPE)."
   (let ((hash-table (make-hash-table :test test-function)))
     (loop for (full-name . value) in parameters
-          for key = (register-groups-bind (name key-string)
+          for key = (ppcre:register-groups-bind (name key-string)
                         ("^(.*){([^{}]+)}$" full-name)
                       (when (string= name parameter-name)
                         (convert-parameter key-string key-type)))
@@ -293,7 +293,7 @@ argument is provided."
     `(progn
        ,@(when uri
            (list
-            (once-only (uri host acceptor-names)
+            (alexandria:once-only (uri host acceptor-names)
               `(progn
                  (setq *easy-handler-alist*
                        (delete-if (lambda (list)

--- a/lispworks.lisp
+++ b/lispworks.lisp
@@ -107,7 +107,7 @@ used to set the timeouts."
                  :read-timeout (acceptor-read-timeout acceptor)
                  #+stream-has-timeouts #+stream-has-timeouts
                  :write-timeout (acceptor-write-timeout acceptor)
-                 :element-type 'octet))
+                 :element-type 'flex:octet))
 
 (defun make-lock (name)
   "Simple wrapper to allow LispWorks and Bordeaux Threads to coexist."

--- a/log.lisp
+++ b/log.lisp
@@ -44,8 +44,8 @@ for every logging operation, which is overall costly.  Web servers
 with high throughput demands should make use of a specialized logging
 function rather than relying on Hunchentoot's default logging
 facility."
-  (with-gensyms (binary-stream)
-    (once-only (destination)
+  (alexandria:with-gensyms (binary-stream)
+    (alexandria:once-only (destination)
       (let ((body body))
         `(when ,destination
            (with-lock-held (,lock)
@@ -53,14 +53,13 @@ facility."
                ((or string pathname)
                 (with-open-file (,binary-stream ,destination
                                                 :direction :output
-                                                :element-type 'octet
+                                                :element-type 'flex:octet
                                                 :if-does-not-exist :create
                                                 :if-exists :append
                                                 #+:openmcl :sharing #+:openmcl :lock)
-                  (let ((,stream-var (make-flexi-stream ,binary-stream :external-format +utf-8+)))
+                  (let ((,stream-var (flex:make-flexi-stream ,binary-stream :external-format +utf-8+)))
                     ,@body)))
                (stream
                 (let ((,stream-var ,destination))
                   (prog1 (progn ,@body)
                     (finish-output ,destination)))))))))))
-  

--- a/packages.lisp
+++ b/packages.lisp
@@ -30,7 +30,45 @@
 
 (defpackage #:hunchentoot
   (:nicknames #:tbnl)
-  (:use :cl :cl-ppcre :chunga :flexi-streams :url-rewrite :alexandria)
+  (:use #:cl)
+  (:import-from #:cl-ppcre
+                #:create-scanner
+                #:scan
+                #:split
+                #:regex-replace
+                #:regex-replace-all
+                #:register-groups-bind)
+  (:import-from #:chunga
+                #:*current-error-message*
+                #:chunked-stream
+                #:chunked-stream-input-chunking-p
+                #:chunked-stream-output-chunking-p
+                #:chunked-stream-stream
+                #:as-capitalized-string
+                #:as-keyword
+                #:make-chunked-stream
+                #:read-http-headers
+                #:read-char*
+                #:read-line*
+                #:read-name-value-pairs
+                #:read-token
+                #:with-character-stream-semantics)
+  (:import-from #:flexi-streams
+                #:*substitution-char*
+                #:flexi-stream-bound
+                #:flexi-stream-position
+                #:make-external-format
+                #:make-flexi-stream
+                #:octets-to-string
+                #:string-to-octets
+                #:octet
+                #:with-input-from-sequence)
+  (:import-from #:alexandria
+                #:when-let
+                #:with-gensyms
+                #:once-only)
+  (:import-from #:url-rewrite
+                #:starts-with-scheme-p)
   (:shadow #:defconstant
            #:url-encode)
   (:export #:*acceptor*

--- a/packages.lisp
+++ b/packages.lisp
@@ -31,44 +31,6 @@
 (defpackage #:hunchentoot
   (:nicknames #:tbnl)
   (:use #:cl)
-  (:import-from #:cl-ppcre
-                #:create-scanner
-                #:scan
-                #:split
-                #:regex-replace
-                #:regex-replace-all
-                #:register-groups-bind)
-  (:import-from #:chunga
-                #:*current-error-message*
-                #:chunked-stream
-                #:chunked-stream-input-chunking-p
-                #:chunked-stream-output-chunking-p
-                #:chunked-stream-stream
-                #:as-capitalized-string
-                #:as-keyword
-                #:make-chunked-stream
-                #:read-http-headers
-                #:read-char*
-                #:read-line*
-                #:read-name-value-pairs
-                #:read-token
-                #:with-character-stream-semantics)
-  (:import-from #:flexi-streams
-                #:*substitution-char*
-                #:flexi-stream-bound
-                #:flexi-stream-position
-                #:make-external-format
-                #:make-flexi-stream
-                #:octets-to-string
-                #:string-to-octets
-                #:octet
-                #:with-input-from-sequence)
-  (:import-from #:alexandria
-                #:when-let
-                #:with-gensyms
-                #:once-only)
-  (:import-from #:url-rewrite
-                #:starts-with-scheme-p)
   (:shadow #:defconstant
            #:url-encode)
   (:export #:*acceptor*

--- a/reply.lisp
+++ b/reply.lisp
@@ -146,7 +146,7 @@ name doesn't exist, it is created.")
      new-value))
   (:method (new-value (name string) &optional (reply *reply*))
    "If NAME is a string, it is converted to a keyword first."
-   (setf (header-out (as-keyword name :destructivep nil) reply) new-value))
+   (setf (header-out (chunga:as-keyword name :destructivep nil) reply) new-value))
   (:method :after (new-value (name (eql :content-length)) &optional (reply *reply*))
    "Special case for the `Content-Length' header."
    (check-type new-value integer)

--- a/specials.lisp
+++ b/specials.lisp
@@ -280,12 +280,12 @@ the debugger).")
   "A list of temporary files created while a request was handled.")
 
 (defconstant +latin-1+
-  (make-external-format :latin1 :eol-style :lf)
+  (flex:make-external-format :latin1 :eol-style :lf)
   "A FLEXI-STREAMS external format used for `faithful' input and
 output of binary data.")
 
 (defconstant +utf-8+
-  (make-external-format :utf8 :eol-style :lf)
+  (flex:make-external-format :utf8 :eol-style :lf)
   "A FLEXI-STREAMS external format used internally for logging and to
 encode cookie values.")
 

--- a/taskmaster.lisp
+++ b/taskmaster.lisp
@@ -401,7 +401,7 @@ is set up via PROCESS-REQUEST."
              (let* ((*hunchentoot-stream* (initialize-connection-stream acceptor *hunchentoot-stream*))
                     (*reply* (make-instance (acceptor-reply-class acceptor)))
                     (*request* (acceptor-make-request acceptor socket)))
-               (with-character-stream-semantics
+               (chunga:with-character-stream-semantics
                  (send-response acceptor
                                 (flex:make-flexi-stream *hunchentoot-stream* :external-format :iso-8859-1)
                                 +http-service-unavailable+
@@ -435,7 +435,7 @@ is set up via PROCESS-REQUEST."
 
 #+:lispworks
 (defmethod shutdown ((taskmaster taskmaster))
-  (when-let (process (acceptor-process (taskmaster-acceptor taskmaster)))
+  (lw:when-let (process (acceptor-process (taskmaster-acceptor taskmaster)))
     ;; kill the main acceptor process, see LW documentation for
     ;; COMM:START-UP-SERVER
     (mp:process-kill process))

--- a/test/packages.lisp
+++ b/test/packages.lisp
@@ -30,7 +30,14 @@
 
 (defpackage #:hunchentoot-test
   (:nicknames #:tbnl-test)
-  (:use :cl :cl-who :hunchentoot)
+  (:use #:cl #:hunchentoot)
+  (:import-from #:cl-who
+                #:esc
+                #:fmt
+                #:htm
+                #:str
+                #:with-html-output
+                #:with-html-output-to-string)
   (:export #:test-hunchentoot))
   
 (defpackage #:hunchentoot-test-user

--- a/test/packages.lisp
+++ b/test/packages.lisp
@@ -31,13 +31,6 @@
 (defpackage #:hunchentoot-test
   (:nicknames #:tbnl-test)
   (:use #:cl #:hunchentoot)
-  (:import-from #:cl-who
-                #:esc
-                #:fmt
-                #:htm
-                #:str
-                #:with-html-output
-                #:with-html-output-to-string)
   (:export #:test-hunchentoot))
   
 (defpackage #:hunchentoot-test-user

--- a/test/test-handlers.lisp
+++ b/test/test-handlers.lisp
@@ -32,15 +32,15 @@
                      (or #.*compile-file-pathname* *load-pathname*)))
 
 (defmacro with-html (&body body)
-  `(with-html-output-to-string (*standard-output* nil :prologue t)
+  `(who:with-html-output-to-string (*standard-output* nil :prologue t)
      ,@body))
 
 (defun hunchentoot-link ()
-  (with-html-output (*standard-output*)
+  (who:with-html-output (*standard-output*)
     (:a :href "http://weitz.de/hunchentoot/" "Hunchentoot")))
 
 (defun menu-link ()
-  (with-html-output (*standard-output*)
+  (who:with-html-output (*standard-output*)
     (:p (:hr
          (:a :href "/hunchentoot/test" "Back to menu")))))
 
@@ -54,7 +54,7 @@
 (defmacro info-table (&rest forms)
   (let ((=value= (gensym))
         (=first= (gensym)))
-    `(with-html-output (*standard-output*)
+    `(who:with-html-output (*standard-output*)
        (:p (:table :border 1 :cellpadding 2 :cellspacing 0
             (:tr (:td :colspan 2
                   "Some Information "
@@ -63,10 +63,10 @@
             ,@(loop for form in forms
                     collect `(:tr (:td :valign "top"
                                    (:pre :style "padding: 0px"
-                                    (esc (with-lisp-output (s) (pprint ',form s)))))
+                                    (who:esc (with-lisp-output (s) (pprint ',form s)))))
                               (:td :valign "top"
                                (:pre :style "padding: 0px"
-                                (esc (with-lisp-output (s)
+                                (who:esc (with-lisp-output (s)
                                        (loop for ,=value= in (multiple-value-list ,form)
                                              for ,=first= = t then nil
                                              unless ,=first=
@@ -113,7 +113,7 @@
         (:h2 (hunchentoot-link) " Information Page")
         (:p "This page has been called "
          (:b
-          (fmt "~[~;once~;twice~:;~:*~R times~]" (incf count)))
+          (who:fmt "~[~;once~;twice~:;~:*~R times~]" (incf count)))
          " since its handler was compiled.")
         (info-table (host)
                     (acceptor-address *acceptor*)
@@ -210,10 +210,10 @@ time or try with cookies disabled.")
         (format nil "text/html; charset=~A" charset))
   (with-html
     (:html
-     (:head (:title (fmt "Hunchentoot ~A parameter test" method)))
+     (:head (:title (who:fmt "Hunchentoot ~A parameter test" method)))
      (:body
       (:h2 (hunchentoot-link)
-       (fmt " ~A parameter test with charset ~A" method charset))
+       (who:fmt " ~A parameter test with charset ~A" method charset))
       (:p "Enter some non-ASCII characters in the input field below
 and see what's happening.")
       (:p (:form
@@ -298,20 +298,20 @@ and see what's happening.")
          :name "file2"))
        (:p (:input :type :submit)))
       (when *tmp-test-files*
-        (htm
+        (who:htm
          (:p
           (:table :border 1 :cellpadding 2 :cellspacing 0
            (:tr (:td :colspan 3 (:b "Uploaded files")))
            (loop for (path file-name nil) in *tmp-test-files*
                  for counter from 1
-                 do (htm
-                     (:tr (:td :align "right" (str counter))
+                 do (who:htm
+                     (:tr (:td :align "right" (who:str counter))
                       (:td (:a :href (format nil "files/~A?path=~A"
                                              (url-encode file-name)
                                              (url-encode (namestring path)))
-                            (esc file-name)))
+                            (who:esc file-name)))
                       (:td :align "right"
-                       (str (ignore-errors
+                       (who:str (ignore-errors
                               (with-open-file (in path)
                                 (file-length in))))
                        "&nbsp;Bytes"))))))
@@ -408,10 +408,10 @@ and see what's happening.")
                                                  (:cmu "CMUCL")
                                                  (:sbcl "SBCL")
                                                  (:openmcl "OpenMCL"))
-                         do (htm
+                         do (who:htm
                              (:option :value value
                               :selected (eq value implementation)
-                              (str option)))))))
+                              (who:str option)))))))
             (:tr
              (:td :valign :top "Meal:")
              (:td (loop for choice in '("Burnt weeny sandwich"
@@ -420,11 +420,11 @@ and see what's happening.")
                                         "Muffin"
                                         "Twenty small cigars"
                                         "Yellow snow")
-                        do (htm
+                        do (who:htm
                             (:input :type "checkbox"
                              :name (format nil "meal{~A}" choice)
                              :checked (gethash choice meal)
-                             (esc choice))
+                             (who:esc choice))
                             (:br)))))
             (:tr
              (:td :valign :top "Team:")
@@ -434,12 +434,12 @@ and see what's happening.")
                                         ;; without accent (for SBCL)
                                         "Pele"
                                         "Zidane")
-                        do (htm
+                        do (who:htm
                             (:input :type "checkbox"
                              :name "team"
                              :value player
                              :checked (member player team :test 'string=)
-                             (esc player))
+                             (who:esc player))
                             (:br)))))
             (:tr
              (:td :colspan 2
@@ -461,7 +461,7 @@ and see what's happening.")
        :href "/hunchentoot/test/favicon.ico" :type "image/x-icon")
       (:title "Hunchentoot test menu"))
      (:body
-      (:h2 (str *headline*))
+      (:h2 (who:str *headline*))
       (:table :border 0 :cellspacing 4 :cellpadding 4
        (:tr (:td (:a :href "/hunchentoot/test/info.html?foo=bar"
                   "Info provided by Hunchentoot")))
@@ -510,7 +510,7 @@ and see what's happening.")
              " \(output depends on "
              (:a :href "http://weitz.de/hunchentoot/#*show-lisp-errors-p*"
               (:code "*SHOW-LISP-ERRORS-P*"))
-             (fmt " \(currently ~S))" *show-lisp-errors-p*)))
+             (who:fmt " \(currently ~S))" *show-lisp-errors-p*)))
        (:tr (:td (:a :href "/hunchentoot/foo"
                   "URI handled by")
              " "


### PR DESCRIPTION
- stop to `use` transitive dependencies
- `import-from` utilized symbols instead