### PR TITLE
Ensure that an EASY-ACCEPTOR is composable with other acceptors

### DIFF
--- a/easy-handlers.lisp
+++ b/easy-handlers.lisp
@@ -348,7 +348,7 @@ either return a handler or neglect by returning NIL."
   (loop for dispatcher in *dispatch-table*
      for action = (funcall dispatcher request)
      when action return (funcall action)
-     finally (call-next-method)))
+     finally (return (call-next-method))))
 
 #-:hunchentoot-no-ssl
 (defclass easy-ssl-acceptor (easy-acceptor ssl-acceptor)


### PR DESCRIPTION
The ACCEPTOR-DISPATCH-REQUEST returns the values resulting from a call to CALL-NEXT-METHOD, to ensure EASY-ACCEPTOR is composable with other acceptors, implementing other ACCEPTOR-DISPATCH-REQUEST methods.  The value returned is important to PROCESS-REQUEST which uses it to determine if the handler used by ACCEPTOR-DISPATCH-REQUEST prepared an in-memory version of the answer or wrote it in the appropriate output stream.

In the previous version of the ACCEPTOR-DISPATCH-REQUEST method for EASY-ACCEPTORS, the values
resulting from a call to CALL-NEXT-METHOD are not not transferred to the caller.