### PR TITLE
Added *default-cookie-same-site* defparameter and set :same-site attr…

### DIFF
--- a/session.lisp
+++ b/session.lisp
@@ -244,6 +244,8 @@ necessary."
                            *session-gc-frequency*)))
       (session-gc))))
 
+(defparameter *default-cookie-same-site* nil)
+
 (defun start-session ()
   "Returns the current SESSION object. If there is no current session,
 creates one and updates the corresponding data structures. In this
@@ -260,6 +262,7 @@ case the function will also send a session cookie to the browser."
     (set-cookie (session-cookie-name *acceptor*)
                 :value (session-cookie-value session)
                 :path "/"
+                :same-site *default-cookie-same-site*
                 :http-only t)
     (session-created *acceptor* session)
     (setq *session* session)))


### PR DESCRIPTION
The same-site attribute was recently introduced in the cookie class to accommodate new requirements in the browser communities (Mozilla initially). The start-session function sets an acceptor's cookie same-site attribute to NIL without an easy way to modify this.  Setting the same-site attribute to  *default-cookie-same-site*  instead leaves the behavior unchanged, yet allows one to change the default behavior more easily. 