### PR TITLE
Fixed attaching ssl-ctx to stream for Lispworks (8).

### DIFF
--- a/ssl.lisp
+++ b/ssl.lisp
@@ -84,7 +84,6 @@ The default port for SSL-ACCEPTOR instances is 443 instead of 80"))
         (certificate-file (acceptor-ssl-certificate-file acceptor))
         (privatekey-file (acceptor-ssl-privatekey-file acceptor)))
     ;; we can do the ssl-ctx setup here, on a per acceptor basis
-    (format t "Setting up SSL context for ~A~%" acceptor)
     (setf (slot-value acceptor 'ssl-ctx) ctx)
     (when privatekey-password
       (comm:set-ssl-ctx-password-callback ctx :password privatekey-password))

--- a/ssl.lisp
+++ b/ssl.lisp
@@ -96,17 +96,18 @@ denoting the location of the files and will be fed directly to
 OpenSSL.  If PRIVATEKEY-PASSWORD is not NIL then it should be the
 password for the private key file \(if necessary).  Returns the
 stream."
-  (flet ((ctx-configure-callback (ctx)
-           (when privatekey-password
-             (comm:set-ssl-ctx-password-callback ctx :password privatekey-password))
-           (comm:ssl-ctx-use-certificate-file ctx
-                                              certificate-file
-                                              comm:ssl_filetype_pem)
-           (comm:ssl-ctx-use-privatekey-file ctx
-                                             privatekey-file
-                                             comm:ssl_filetype_pem)))
+  (let ((ctx (comm:make-ssl-ctx)))
+    (when privatekey-password
+      (comm:set-ssl-ctx-password-callback ctx :password privatekey-password))
+    (comm:ssl-ctx-use-certificate-file ctx
+                                       certificate-file
+                                       comm:ssl_filetype_pem)
+    (comm:ssl-ctx-use-privatekey-file ctx
+                                      privatekey-file
+                                      comm:ssl_filetype_pem)
     (comm:attach-ssl socket-stream
-                     :ctx-configure-callback #'ctx-configure-callback)
+                     :ssl-side :server
+                     :ssl-ctx ctx)
     socket-stream))
 
 #+:lispworks


### PR DESCRIPTION
This implementation now manually creates a ssl-ctx-pointer via `comm:make-ssl-ctx` and configures the certificate and private key on it, which is then attached to the stream.
Previously, `attach-ssl` was called with a symbol parameter for `ssl-ctx` and a callback function. But the callback function was not called.