### PR TITLE
Feat: add partitioned cookie attribute

### DIFF
--- a/cookie.lisp
+++ b/cookie.lisp
@@ -62,6 +62,13 @@ cookie expires \(or NIL).")
            :documentation "The SameSite attribute for the cookie, needs
 to be one of \"None\", \"Lax\" or \"Strict\". Defaults to \"None\". See
 <https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-02#section-5.3.7>.")
+   (partitioned :initarg :partitioned
+		:initform nil
+		:accessor cookie-partitioned
+		:documentation "The Partitioned attribute is a generalized
+boolean denoting whether this cookie uses partitioned storage with a separate
+cookie jar for each top-level site. This should prevent cross-site tracking
+while safeguarding user privacy.")
    (secure :initarg :secure
            :initform nil
            :accessor cookie-secure
@@ -97,7 +104,7 @@ REPLY object REPLY. If a cookie with the same name
         (push (cons name cookie) (cookies-out reply))
         cookie))))
 
-(defun set-cookie (name &key (value "") expires max-age path domain same-site secure http-only (reply *reply*))
+(defun set-cookie (name &key (value "") expires max-age path domain same-site partitioned secure http-only (reply *reply*))
   "Creates a cookie object from the parameters provided and adds
 it to the outgoing cookies of the REPLY object REPLY. If a cookie
 with the name NAME \(case-sensitive) already exists, it is
@@ -110,6 +117,7 @@ replaced."
                               :path path
                               :domain domain
                               :same-site same-site
+			      :partitioned partitioned
                               :secure secure
                               :http-only http-only)
                reply))
@@ -123,7 +131,7 @@ replaced."
   "Converts the COOKIE object COOKIE to a string suitable for a
 'Set-Cookie' header to be sent to the client."
   (format nil
-          "~A=~A~@[; Expires=~A~]~@[; Max-Age=~A~]~@[; Domain=~A~]~@[; Path=~A~]~@[; SameSite=~A~]~:[~;; Secure~]~:[~;; HttpOnly~]"
+          "~A=~A~@[; Expires=~A~]~@[; Max-Age=~A~]~@[; Domain=~A~]~@[; Path=~A~]~@[; SameSite=~A~]~:[~;; Partitioned~]~:[~;; Secure~]~:[~;; HttpOnly~]"
           (cookie-name cookie)
           (cookie-value cookie)
           (cookie-date (cookie-expires cookie))
@@ -131,5 +139,6 @@ replaced."
           (cookie-domain cookie)
           (cookie-path cookie)
           (cookie-same-site cookie)
+	  (cookie-partitioned cookie)
           (cookie-secure cookie)
           (cookie-http-only cookie)))


### PR DESCRIPTION
The `Partitioned` attribute is a generalized boolean denoting whether this cookie uses partitioned storage with a separate cookie jar for each top-level site. This should prevent cross-site tracking while safeguarding user privacy.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#partitioned