### PR TITLE
Communicating over unix domain sockets

### DIFF
--- a/acceptor.lisp
+++ b/acceptor.lisp
@@ -330,6 +330,9 @@ they're using secure connections - see the SSL-ACCEPTOR class."))
   #-lispworks
   (usocket:socket-close (acceptor-listen-socket acceptor))
   #-lispworks
+  (when (pathnamep (acceptor-address acceptor))
+    (uiop:delete-file-if-exists (acceptor-address acceptor)))
+  #-lispworks
   (setf (acceptor-listen-socket acceptor) nil)
   #+lispworks
   (mp:process-kill (acceptor-process acceptor))
@@ -340,20 +343,24 @@ they're using secure connections - see the SSL-ACCEPTOR class."))
   "Creates a dummy connection to the acceptor, waking ACCEPT-CONNECTIONS while it is waiting.
 This is supposed to force a check of ACCEPTOR-SHUTDOWN-P."
   (handler-case
-      (multiple-value-bind (address port) (usocket:get-local-name (acceptor-listen-socket acceptor))
-        (let ((conn (usocket:socket-connect
-                     (cond
-                       ;; 0.0.0.0/8 is invalid as the target for a
-                       ;; connection, so we have to use something
-                       ;; else.
-                       ((and (= (length address) 4) (zerop (elt address 0)))
-                        #(127 0 0 1))
-                       ;; In IPv6, :: is similarly reserved.
-                       ((and (= (length address) 16)
-                             (every #'zerop address))
-                        #(0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1))
-                       (t address))
-                     port)))
+      (multiple-value-bind (raw-address port) (usocket:get-local-name (acceptor-listen-socket acceptor))
+        (let* ((address (cond
+                          ;; 0.0.0.0/8 is invalid as the target for a
+                          ;; connection, so we have to use something
+                          ;; else.
+                          ((and (= (length raw-address) 4) (zerop (elt raw-address 0)))
+                           #(127 0 0 1))
+                          ;; In IPv6, :: is similarly reserved.
+                          ((and (= (length raw-address) 16)
+                                (every #'zerop raw-address))
+                           #(0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1))
+                          ((stringp raw-address)
+                           (merge-pathnames raw-address))
+                          (t raw-address)))
+               (conn (usocket:socket-connect
+                      address
+                      port
+                      :nodelay (if (pathnamep address) nil t))))
           (usocket:socket-close conn)))
     (error (e)
       (acceptor-log-message acceptor :error "Wake-for-shutdown connect failed: ~A" e))))

--- a/taskmaster.lisp
+++ b/taskmaster.lisp
@@ -330,7 +330,10 @@ implementations."))
    (start-thread
     taskmaster
     (lambda () (handle-incoming-connection% taskmaster socket))
-    :name (format nil (taskmaster-worker-thread-name-format taskmaster) (client-as-string socket)))
+    :name (format nil (taskmaster-worker-thread-name-format taskmaster)
+                  (if (pathnamep (acceptor-address (taskmaster-acceptor taskmaster)))
+                      (acceptor-address (taskmaster-acceptor taskmaster))
+                      (client-as-string socket))))
    (error (cond)
           ;; need to bind *ACCEPTOR* so that LOG-MESSAGE* can do its work.
           (let ((*acceptor* (taskmaster-acceptor taskmaster)))


### PR DESCRIPTION
I had a plan to run multiple Hunchentoot instances on my local machine, put the Caddy web server up front and have Caddy communicate to Hunchentoot via unix domain sockets. 

Connecting wasn't a problem but shutdown errored so I thought I give it a try and look whats causing the error. This PR is the result. 

Disclaimer: This lacks some more testing especially on LispWorks 😅

Thank you. I'm open for suggestions and improvements.