### PR TITLE
Remove exported but unused symbol

### DIFF
--- a/packages.lisp
+++ b/packages.lisp
@@ -44,7 +44,6 @@
            #:*default-content-type*
            #:*dispatch-table*
            #:*file-upload-hook*
-           #:*handle-http-errors-p*
            #:*header-stream*
            #:*http-error-handler*
            #:*hunchentoot-default-external-format*


### PR DESCRIPTION
The special variable `*handle-http-errors-p*` has been removed for a long time now, maybe we can remove the symbol from the package declaration. This may break some user code.