### PR TITLE
Specialize stream-line-column on formatting-stream (fixes #238)

### DIFF
--- a/make-docstrings.lisp
+++ b/make-docstrings.lisp
@@ -56,7 +56,7 @@
          (vector-push-extend char (word-buffer stream))))
       (write-char char (understream stream))))
 
-(defmethod trivial-gray-streams:stream-line-column (stream)
+(defmethod trivial-gray-streams:stream-line-column ((stream formatting-stream))
   (+ (column stream) (length (word-buffer stream))))
 
 (defmethod trivial-gray-streams:stream-write-string ((stream formatting-stream) string &optional start end)


### PR DESCRIPTION
## Summary

Fixes the `stream-line-column` method to specialize on `formatting-stream` instead of being unspecialized.

Fixes #238

## Problem

On LispWorks, `stream-line-column` is exported and the implementation doesn't allow methods that are not specialized (i.e., specialized on `T`) for such generic functions. This causes an error when loading the docstring generation code.

## Change

```lisp
;; Before
(defmethod trivial-gray-streams:stream-line-column (stream) ...)

;; After  
(defmethod trivial-gray-streams:stream-line-column ((stream formatting-stream)) ...)

## Testing

- Build verified on SBCL
- Not tested on LispWorks (don't have access) - would appreciate if @Yehouda could verify