### PR TITLE
Refine error handling in acceptor.lisp

### DIFF
--- a/acceptor.lisp
+++ b/acceptor.lisp
@@ -679,7 +679,7 @@ handler."
                     (when *headers-sent*
                       (setq *finish-processing-socket* t))
                     (throw 'handler-done
-                      (values nil cond (get-backtrace))))))
+                      (values nil (princ-to-string cond) (get-backtrace))))))
     (with-debugger
       (acceptor-dispatch-request *acceptor* *request*))))
 


### PR DESCRIPTION
Updated error handling to provide a string representation of the condition along with the backtrace.

The handler was returning both `cond` and the backtrace string. In my test, `cond` was a `no-applicable-method condition`. That condition still contains the original generic function arguments, one of which was the dynamic-extent `with-output-to-string` stream, which escaped (undefined behavior, producing memory corruption).