### PR TITLE
Fix reason-phrase docstring to match actual behavior

### DIFF
--- a/util.lisp
+++ b/util.lisp
@@ -56,7 +56,8 @@ digits."
 
 (defun reason-phrase (return-code)
   "Returns a reason phrase for the HTTP return code RETURN-CODE \(which
-should be an integer) or NIL for return codes Hunchentoot doesn't know."
+should be an integer) or the string \"No reason phrase known\" for
+return codes that are not in *HTTP-REASON-PHRASE-MAP*."
   (gethash return-code *http-reason-phrase-map* 
            "No reason phrase known"))
 


### PR DESCRIPTION
## Description

The docstring for `REASON-PHRASE` in `util.lisp` incorrectly states that
the function returns NIL for unknown return codes. In reality, it returns
the string `"No reason phrase known"` via the `GETHASH` default value.

### Before

```lisp
(defun reason-phrase (return-code)
  "Returns a reason phrase for the HTTP return code RETURN-CODE (which
should be an integer) or NIL for return codes Hunchentoot doesn't know."
  (gethash return-code *http-reason-phrase-map*
           "No reason phrase known"))
```

### After

```lisp
(defun reason-phrase (return-code)
  "Returns a reason phrase for the HTTP return code RETURN-CODE (which
should be an integer) or the string \"No reason phrase known\" for
return codes that are not in *HTTP-REASON-PHRASE-MAP*."
  (gethash return-code *http-reason-phrase-map*
           "No reason phrase known"))
```

This addresses only the documentation bug portion of #246. The
extensibility discussion (making `REASON-PHRASE` a generic function
or otherwise parameterizable) is a separate concern and could be
addressed in a follow-up if desired.

Fixes #246